### PR TITLE
Fix merging user ignoreWords with global whitelist

### DIFF
--- a/packages/js/src/core/index.ts
+++ b/packages/js/src/core/index.ts
@@ -5,7 +5,10 @@ import globalWhitelistData from '@shared/dictionaries/globalWhitelist.json';
 function createFilterConfig(config?: ProfanityCheckerConfig): FilterConfig {
   const effective: FilterConfig = {
     ...(config ?? {}),
-    ignoreWords: (globalWhitelistData as { whitelist: string[] }).whitelist,
+    ignoreWords: [
+      ...(globalWhitelistData as { whitelist: string[] }).whitelist,
+      ...(config?.ignoreWords ?? []),
+    ],
     fuzzyToleranceLevel: config?.fuzzyToleranceLevel ?? 0.8,
   };
 


### PR DESCRIPTION
## Fix merging user ignoreWords with global whitelist

### Description

When passing in a custom list of ignore words, I noticed none of them were being respected. I noticed that the ignoreWords provided by the user config were not being included when the global ignore words are added.

- **What has changed?**
  - [ ] New feature
  - [x] Bug fix
  - [ ] Documentation update
  - [ ] Other (describe)

### Changes Checklist

Please ensure your PR meets the following criteria:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation (if applicable).

### How Has This Been Tested?

I tested this change manually but did not add unit tests. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed word filtering to properly combine user-specified ignore words with the global default list, enabling more granular control over filter behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->