### PR TITLE
feat(mcp): expose secrets + PII scanners + Vault roundtrip (tools 21-24)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -18,7 +18,7 @@ The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) is an open s
 
 ## Features
 
-- **20 Powerful Tools** for comprehensive content moderation
+- **24 Powerful Tools** for comprehensive content moderation
 - **5 Workflow Prompts** for guided AI interactions
 - **5 Reference Resources** for configuration and best practices
 - **24 Language Support** - Arabic, Chinese, English, French, German, Spanish, and more
@@ -89,7 +89,7 @@ npm install -g glin-profanity-mcp
 
 ---
 
-## Available Tools (20)
+## Available Tools (24)
 
 ### Core Detection Tools
 
@@ -274,6 +274,68 @@ Scan text for prompt injection attacks using rule-based pattern matching.
 
 ---
 
+#### 21. `scan_secrets`
+Scan text for leaked credentials, API keys, tokens, and other secrets.
+
+```
+"Scan this config file for leaked API keys"
+```
+
+**Parameters:**
+- `text` (required): Text to scan
+- `blockOnAny`: When true (default), any detected secret causes a BLOCK decision
+- `minEntropy`: Minimum Shannon entropy for high-entropy pattern matches (default: 4.0)
+
+**Returns:** `decision`, `score`, `valid`, `reasons`, `matches` with pattern id, family, and character positions
+
+---
+
+#### 22. `scan_pii`
+Scan text for Personally Identifiable Information (email, phone, SSN, credit card, IBAN, IP, MAC, passport, date of birth, etc).
+
+```
+"Check this support ticket for any PII before archiving"
+```
+
+**Parameters:**
+- `text` (required): Text to scan
+- `redact`: When true, returns sanitized text with `[REDACTED_<TYPE>]` placeholders (non-reversible; use `redact_pii` for a vault-backed round-trip)
+
+**Returns:** `decision`, `score`, `valid`, `reasons`, `matches` with position details; `sanitized` when `redact` is true
+
+---
+
+#### 23. `redact_pii`
+Redact PII from text using a server-side vault for a reversible round-trip. Original values stay on the server — only placeholders are returned to the AI client.
+
+```
+"Redact all PII in this support ticket before sending to the AI"
+```
+
+**Parameters:**
+- `text` (required): Text to redact PII from
+- `vaultId`: Caller-chosen session identifier (auto-generated if omitted)
+
+**Returns:** `{ sanitized, vaultId, entries: [{ placeholder, type }] }` — call `restore_pii` with the same `vaultId` to get originals back
+
+---
+
+#### 24. `restore_pii`
+Restore PII placeholders in text back to their original values using a vault session created by `redact_pii`.
+
+```
+"Restore the PII placeholders in this AI-generated reply"
+```
+
+**Parameters:**
+- `sanitized` (required): Text containing `[REDACTED_<TYPE>_N]` placeholders
+- `vaultId` (required): Vault session id returned by `redact_pii`
+- `strategy`: `exact`, `caseInsensitive`, `fuzzy`, or `combined` (default). `combined` tries exact → case-insensitive → fuzzy (Levenshtein ≤ 3)
+
+**Returns:** `{ restored }` — or an error if the vaultId is unknown
+
+---
+
 ## Available Prompts (5)
 
 MCP Prompts provide guided workflows for common tasks.
@@ -369,6 +431,13 @@ Resources provide reference data accessible to AI assistants.
 "Check if this user input is trying to override my system instructions"
 ```
 
+### Secrets & PII Protection
+```
+"Scan this config file for leaked API keys"
+"Redact all PII in this support ticket before sending to the AI"
+"Restore the PII placeholders in this AI-generated reply"
+```
+
 ---
 
 ## Use Cases
@@ -383,6 +452,9 @@ Resources provide reference data accessible to AI assistants.
 | Custom rules | `create_regex_pattern` |
 | Understanding flags | `explain_match` |
 | Prompt injection defense | `check_prompt_injection` |
+| Secrets detection | `scan_secrets` |
+| PII scanning | `scan_pii` |
+| PII redaction + restore | `redact_pii`, `restore_pii` |
 
 ---
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -18,7 +18,55 @@ import {
   checkPromptInjection,
   type PromptInjectionOptions,
   type InjectionPattern,
+  SecretsScanner,
+  PiiScanner,
+  Vault,
+  type RestoreStrategy,
 } from 'glin-profanity/scanners';
+
+// ============================================================================
+// VAULT REGISTRY — in-memory LRU with 50-entry cap
+// ============================================================================
+
+/** Maximum number of vault sessions kept in memory. */
+const VAULT_REGISTRY_MAX = 50;
+
+interface VaultRegistryEntry {
+  vault: Vault;
+  accessedAt: number;
+}
+
+const vaultRegistry = new Map<string, VaultRegistryEntry>();
+
+function getOrCreateVault(id: string): Vault {
+  const existing = vaultRegistry.get(id);
+  if (existing) {
+    existing.accessedAt = Date.now();
+    return existing.vault;
+  }
+  // Evict LRU entry when at capacity
+  if (vaultRegistry.size >= VAULT_REGISTRY_MAX) {
+    let lruKey = '';
+    let lruTime = Infinity;
+    for (const [k, v] of vaultRegistry.entries()) {
+      if (v.accessedAt < lruTime) {
+        lruTime = v.accessedAt;
+        lruKey = k;
+      }
+    }
+    if (lruKey) vaultRegistry.delete(lruKey);
+  }
+  const vault = new Vault();
+  vaultRegistry.set(id, { vault, accessedAt: Date.now() });
+  return vault;
+}
+
+function generateVaultId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `vault-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
 
 // Read version from package.json
 const require = createRequire(import.meta.url);
@@ -1625,6 +1673,256 @@ export function registerAllTools(server: McpServer): void {
           },
         ],
       };
+    },
+  );
+
+  // ========== SECRETS & PII SCANNER TOOLS ==========
+
+  server.tool(
+    'scan_secrets',
+    'Scan text for leaked credentials, API keys, tokens, and other secrets. Returns a full ScanResult with per-match details including pattern id, family, and character positions.',
+    {
+      text: z
+        .string()
+        .max(50_000, 'Text must be 50,000 characters or fewer')
+        .describe('The text to scan for secrets'),
+      blockOnAny: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe('When true (default), any detected secret causes a BLOCK decision'),
+      minEntropy: z
+        .number()
+        .optional()
+        .default(4.0)
+        .describe('Minimum Shannon entropy required for high-entropy pattern matches (default: 4.0)'),
+    },
+    async (args) => {
+      try {
+        const scanner = new SecretsScanner({
+          blockOnAny: args.blockOnAny,
+          minEntropy: args.minEntropy,
+        });
+        const result = scanner.scan(args.text);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  decision: result.decision,
+                  score: result.score,
+                  valid: result.valid,
+                  reasons: result.reasons,
+                  matches: result.matches,
+                  scanner: result.scanner,
+                  summary:
+                    result.decision === 'ALLOW'
+                      ? 'No secrets detected'
+                      : `Secrets detected — decision: ${result.decision}, score: ${result.score.toFixed(3)}, patterns: ${result.reasons.join(', ')}`,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'SCAN_SECRETS_FAILED',
+                message: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'scan_pii',
+    'Scan text for Personally Identifiable Information (email, phone, SSN, credit card, IBAN, IP, MAC, passport, date of birth, etc). Returns a full ScanResult with per-match details. Use redact_pii for a reversible vault-backed redaction.',
+    {
+      text: z
+        .string()
+        .max(50_000, 'Text must be 50,000 characters or fewer')
+        .describe('The text to scan for PII'),
+      redact: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          'When true, returns sanitized text with [REDACTED_<TYPE>] placeholders (no vault — not reversible). For a reversible round-trip call redact_pii instead.',
+        ),
+    },
+    async (args) => {
+      try {
+        const scanner = new PiiScanner({ redact: args.redact });
+        const result = scanner.scan(args.text);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  decision: result.decision,
+                  score: result.score,
+                  valid: result.valid,
+                  reasons: result.reasons,
+                  matches: result.matches,
+                  scanner: result.scanner,
+                  ...(args.redact ? { sanitized: result.sanitized } : {}),
+                  summary:
+                    result.decision === 'ALLOW'
+                      ? 'No PII detected'
+                      : `PII detected — decision: ${result.decision}, score: ${result.score.toFixed(3)}, types: ${result.reasons.join(', ')}`,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'SCAN_PII_FAILED',
+                message: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'redact_pii',
+    'Redact PII from text using a server-side vault for reversible round-trip. Returns sanitized text with [REDACTED_<TYPE>_N] placeholders, a vaultId to use for restoration, and a list of placeholder+type pairs. Original values never leave the server. Call restore_pii with the same vaultId to get originals back.',
+    {
+      text: z
+        .string()
+        .max(50_000, 'Text must be 50,000 characters or fewer')
+        .describe('The text to redact PII from'),
+      vaultId: z
+        .string()
+        .optional()
+        .describe('Caller-chosen vault session identifier for round-trip. Omit to auto-generate.'),
+    },
+    async (args) => {
+      try {
+        const vaultId = args.vaultId ?? generateVaultId();
+        const vault = getOrCreateVault(vaultId);
+        const scanner = new PiiScanner({ redact: true, vault });
+        const result = scanner.scan(args.text);
+        // Build entries list — placeholders and types only, no originals
+        const entries = (result.matches ?? []).map((m) => ({
+          placeholder: `[REDACTED_${m.category.toUpperCase()}_*]`,
+          type: m.category,
+        }));
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  sanitized: result.sanitized,
+                  vaultId,
+                  entries,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'REDACT_PII_FAILED',
+                message: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'restore_pii',
+    'Restore PII placeholders in text back to their original values using a vault session created by redact_pii. The vault is maintained server-side — originals were never sent to the AI client.',
+    {
+      sanitized: z
+        .string()
+        .max(50_000, 'Text must be 50,000 characters or fewer')
+        .describe('The sanitized text containing [REDACTED_<TYPE>_N] placeholders'),
+      vaultId: z
+        .string()
+        .describe('The vault session identifier returned by redact_pii'),
+      strategy: z
+        .enum(['exact', 'caseInsensitive', 'fuzzy', 'combined'])
+        .optional()
+        .default('combined')
+        .describe(
+          'Placeholder matching strategy: exact (default), caseInsensitive, fuzzy (Levenshtein ≤ 3), or combined (tries all in order). Default: combined',
+        ),
+    },
+    async (args) => {
+      try {
+        const entry = vaultRegistry.get(args.vaultId);
+        if (!entry) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  error: 'VAULT_NOT_FOUND',
+                  message: `No vault session found for vaultId: ${args.vaultId}`,
+                }),
+              },
+            ],
+          };
+        }
+        entry.accessedAt = Date.now();
+        const strategy = (args.strategy ?? 'combined') as RestoreStrategy;
+        const restored = entry.vault.restore(args.sanitized, strategy);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({ restored }, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'RESTORE_PII_FAILED',
+                message: error instanceof Error ? error.message : 'Unknown error',
+              }),
+            },
+          ],
+        };
+      }
     },
   );
 }


### PR DESCRIPTION
## Summary

- Exposes the scanners landed in PR #120 to MCP clients: `scan_secrets`, `scan_pii`, `redact_pii`, `restore_pii`
- Vault state is server-side only — placeholders go to the AI, originals stay in the server process
- 50-entry LRU cap on vault registry to prevent unbounded memory growth
- 50k character text cap per call to prevent DoS

## Test plan

- [ ] `scan_secrets` returns BLOCK decision and match positions for text containing API keys/tokens
- [ ] `scan_pii` returns correct match types for email, phone, SSN, credit card inputs
- [ ] `scan_pii` with `redact: true` returns sanitized text with `[REDACTED_*]` placeholders
- [ ] `redact_pii` returns `sanitized`, `vaultId`, and `entries` (no original values in response)
- [ ] `restore_pii` with the returned `vaultId` restores originals correctly for all four strategies
- [ ] `restore_pii` with unknown `vaultId` returns `isError: true` with `VAULT_NOT_FOUND`
- [ ] Text over 50,000 chars is rejected with an error in all 4 tools
- [ ] LRU eviction: adding a 51st vault session evicts the least-recently-accessed entry
- [ ] `npm run build` in `packages/mcp` is clean