### PR TITLE
feat(py): port PII + secrets + Vault scanners

### DIFF
--- a/packages/py/glin_profanity/__init__.py
+++ b/packages/py/glin_profanity/__init__.py
@@ -78,11 +78,23 @@ __all__ = [
     "PromptInjectionScanner",
     "check_prompt_injection",
     "default_prompt_injection_scanner",
+    # Secrets scanner
+    "SecretsScanner",
+    "scan_secrets",
+    # PII scanner
+    "PiiScanner",
+    "scan_pii",
+    # Vault
+    "Vault",
+    "RestoreStrategy",
 ]
 
 from .scanners.base import Scanner, ScanDecision, ScanMatch, ScanResult
+from .scanners.pii import PiiScanner, scan_pii
 from .scanners.prompt_injection import (
     PromptInjectionScanner,
     check_prompt_injection,
     default_prompt_injection_scanner,
 )
+from .scanners.secrets import SecretsScanner, scan_secrets
+from .scanners.vault import RestoreStrategy, Vault

--- a/packages/py/glin_profanity/scanners/__init__.py
+++ b/packages/py/glin_profanity/scanners/__init__.py
@@ -9,11 +9,16 @@ from .base import (
     block_result,
 )
 from .patterns.injection_patterns import INJECTION_PATTERNS, InjectionPattern
+from .patterns.pii_patterns import PII_PATTERNS, PiiPattern
+from .patterns.secret_patterns import SECRET_PATTERNS, SecretPattern
+from .pii import PiiScanner, scan_pii
 from .prompt_injection import (
     PromptInjectionScanner,
     check_prompt_injection,
     default_prompt_injection_scanner,
 )
+from .secrets import SecretsScanner, scan_secrets
+from .vault import RestoreStrategy, Vault
 
 __all__ = [
     # Base
@@ -26,8 +31,21 @@ __all__ = [
     # Patterns
     "INJECTION_PATTERNS",
     "InjectionPattern",
+    "PII_PATTERNS",
+    "PiiPattern",
+    "SECRET_PATTERNS",
+    "SecretPattern",
     # Prompt injection scanner
     "PromptInjectionScanner",
     "check_prompt_injection",
     "default_prompt_injection_scanner",
+    # Secrets scanner
+    "SecretsScanner",
+    "scan_secrets",
+    # PII scanner
+    "PiiScanner",
+    "scan_pii",
+    # Vault
+    "Vault",
+    "RestoreStrategy",
 ]

--- a/packages/py/glin_profanity/scanners/patterns/__init__.py
+++ b/packages/py/glin_profanity/scanners/patterns/__init__.py
@@ -1,5 +1,16 @@
-"""Injection pattern database package."""
+"""Pattern database package — injection, secrets, and PII patterns."""
 
 from .injection_patterns import INJECTION_PATTERNS, InjectionPattern
+from .pii_patterns import PII_PATTERNS, PiiPattern, iban_check, luhn_check
+from .secret_patterns import SECRET_PATTERNS, SecretPattern
 
-__all__ = ["INJECTION_PATTERNS", "InjectionPattern"]
+__all__ = [
+    "INJECTION_PATTERNS",
+    "InjectionPattern",
+    "PII_PATTERNS",
+    "PiiPattern",
+    "luhn_check",
+    "iban_check",
+    "SECRET_PATTERNS",
+    "SecretPattern",
+]

--- a/packages/py/glin_profanity/scanners/patterns/pii_patterns.py
+++ b/packages/py/glin_profanity/scanners/patterns/pii_patterns.py
@@ -1,0 +1,405 @@
+"""
+PII (Personally Identifiable Information) detection patterns.
+
+Pattern attribution:
+  - ProtectAI/llm-guard (MIT) — https://github.com/protectai/llm-guard
+  - Yelp/detect-secrets (Apache-2.0) — https://github.com/Yelp/detect-secrets
+
+Patterns have been reimplemented in Python — no source was copied verbatim.
+
+Mirrors packages/js/src/scanners/patterns/pii-patterns.ts.
+
+@module scanners/patterns/pii_patterns
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Callable, Literal, Optional
+
+PiiType = Literal[
+    "email",
+    "phone",
+    "ssn",
+    "credit_card",
+    "iban",
+    "ip",
+    "mac",
+    "postcode",
+    "passport",
+    "dob",
+    "other",
+]
+
+
+@dataclass
+class PiiPattern:
+    """A single PII detection rule."""
+
+    id: str
+    """Unique identifier, e.g. 'PII-EMAIL-001'."""
+
+    type: PiiType
+    """Category of PII."""
+
+    pattern: re.Pattern[str]
+    """Compiled regular expression for detection."""
+
+    validator: Optional[Callable[[str], bool]] = None
+    """
+    Optional post-match validator.
+    If provided, a match only counts as PII when this returns True.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Validators
+# ---------------------------------------------------------------------------
+
+
+def luhn_check(value: str) -> bool:
+    """
+    Luhn algorithm validator for credit card numbers.
+    Strips spaces and dashes before checking.
+    """
+    digits = re.sub(r"[\s\-]", "", value)
+    if not re.match(r"^\d+$", digits):
+        return False
+
+    total = 0
+    should_double = False
+
+    for i in range(len(digits) - 1, -1, -1):
+        d = int(digits[i])
+        if should_double:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+        should_double = not should_double
+
+    return total % 10 == 0
+
+
+def iban_check(value: str) -> bool:
+    """
+    Basic IBAN mod-97 structural validator.
+    Does NOT check country-specific length rules; validates the mod-97 checksum.
+    """
+    cleaned = re.sub(r"[\s\-]", "", value).upper()
+    if not re.match(r"^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$", cleaned):
+        return False
+
+    # Move first 4 chars to end, convert letters to numbers
+    rearranged = cleaned[4:] + cleaned[:4]
+    numeric_parts: list[str] = []
+    for c in rearranged:
+        code = ord(c)
+        if 65 <= code <= 90:
+            numeric_parts.append(str(code - 55))
+        else:
+            numeric_parts.append(c)
+    numeric = "".join(numeric_parts)
+
+    # BigInt mod 97 (IBAN can be >15 digits)
+    remainder = 0
+    for ch in numeric:
+        remainder = (remainder * 10 + int(ch)) % 97
+
+    return remainder == 1
+
+
+# ---------------------------------------------------------------------------
+# Email
+# ---------------------------------------------------------------------------
+
+_EMAIL_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-EMAIL-001",
+        type="email",
+        # RFC-5321 compliant enough for practical use
+        pattern=re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Phone Numbers
+# ---------------------------------------------------------------------------
+
+_PHONE_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-PHONE-001",
+        type="phone",
+        # E.164 format
+        pattern=re.compile(r"\+[1-9][0-9]{6,14}\b"),
+    ),
+    PiiPattern(
+        id="PII-PHONE-002",
+        type="phone",
+        # US/CA NANP: (XXX) XXX-XXXX or XXX-XXX-XXXX or XXX.XXX.XXXX
+        pattern=re.compile(
+            r"(?:\+1[\s\-.]?)?\(?[2-9][0-9]{2}\)?[\s\-.]?[2-9][0-9]{2}[\s\-.]?[0-9]{4}\b"
+        ),
+    ),
+    PiiPattern(
+        id="PII-PHONE-003",
+        type="phone",
+        # UK phone: 07xxx xxxxxx or +44 7xxx xxxxxx
+        pattern=re.compile(r"(?:\+44|0)[0-9]{2,4}[\s\-]?[0-9]{3,4}[\s\-]?[0-9]{4}\b"),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# SSN / Tax IDs
+# ---------------------------------------------------------------------------
+
+_SSN_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-SSN-001",
+        type="ssn",
+        # US Social Security Number (not 000, not 666, not 900-999)
+        pattern=re.compile(
+            r"\b(?!000|666|9[0-9][0-9])[0-9]{3}[-\s](?!00)[0-9]{2}[-\s](?!0000)[0-9]{4}\b"
+        ),
+    ),
+    PiiPattern(
+        id="PII-ITIN-001",
+        type="ssn",
+        # US Individual Taxpayer Identification Number (9XX-7X-XXXX or 9XX-8X-XXXX)
+        pattern=re.compile(r"\b9[0-9]{2}[-\s](?:7[0-9]|8[0-8])[-\s][0-9]{4}\b"),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Credit Cards
+# ---------------------------------------------------------------------------
+
+_CREDIT_CARD_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-CC-001",
+        type="credit_card",
+        # Visa / Mastercard / Amex / Discover — 13-19 digits with optional separators
+        pattern=re.compile(
+            r"\b(?:4[0-9]{3}|5[1-5][0-9]{2}|3[47][0-9]{2}|6(?:011|5[0-9]{2}))"
+            r"[0-9 \-]{8,15}[0-9]\b"
+        ),
+        validator=luhn_check,
+    ),
+    PiiPattern(
+        id="PII-CC-002",
+        type="credit_card",
+        # Generic 16-digit card with separators
+        pattern=re.compile(
+            r"\b[0-9]{4}[\ \-]?[0-9]{4}[\ \-]?[0-9]{4}[\ \-]?[0-9]{4}\b"
+        ),
+        validator=luhn_check,
+    ),
+    PiiPattern(
+        id="PII-CC-003",
+        type="credit_card",
+        # Amex: 15-digit, starts with 34 or 37
+        pattern=re.compile(r"\b3[47][0-9]{2}[\s\-]?[0-9]{6}[\s\-]?[0-9]{5}\b"),
+        validator=luhn_check,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# IBAN
+# ---------------------------------------------------------------------------
+
+_IBAN_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-IBAN-001",
+        type="iban",
+        # Standard IBAN format: 2-letter country, 2 check digits, up to 30 alphanumeric
+        pattern=re.compile(r"\b[A-Z]{2}[0-9]{2}[A-Z0-9]{4}[0-9]{7}(?:[A-Z0-9]{0,16})\b"),
+        validator=iban_check,
+    ),
+    PiiPattern(
+        id="PII-IBAN-002",
+        type="iban",
+        # IBAN with spaces (printed format: groups of 4)
+        pattern=re.compile(r"\b[A-Z]{2}[0-9]{2}(?:\s[A-Z0-9]{4}){2,7}\b"),
+        validator=iban_check,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# IP Addresses
+# ---------------------------------------------------------------------------
+
+_IP_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-IPV4-001",
+        type="ip",
+        # IPv4 (non-private ranges included — scanner user decides what to block)
+        pattern=re.compile(
+            r"\b(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+            r"\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+            r"\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+            r"\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b"
+        ),
+    ),
+    PiiPattern(
+        id="PII-IPV6-001",
+        type="ip",
+        # Full IPv6
+        pattern=re.compile(r"\b(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\b"),
+    ),
+    PiiPattern(
+        id="PII-IPV6-002",
+        type="ip",
+        # Compressed IPv6 (e.g. 2001:db8::1)
+        pattern=re.compile(
+            r"\b(?:[A-Fa-f0-9]{1,4}:){1,7}:\b|\b:[A-Fa-f0-9]{1,4}(?::[A-Fa-f0-9]{1,4}){1,7}\b"
+        ),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# MAC Address
+# ---------------------------------------------------------------------------
+
+_MAC_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-MAC-001",
+        type="mac",
+        # Colon-separated MAC
+        pattern=re.compile(r"\b(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b"),
+    ),
+    PiiPattern(
+        id="PII-MAC-002",
+        type="mac",
+        # Hyphen-separated MAC
+        pattern=re.compile(r"\b(?:[0-9A-Fa-f]{2}-){5}[0-9A-Fa-f]{2}\b"),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Postcodes
+# ---------------------------------------------------------------------------
+
+_POSTCODE_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-ZIP-001",
+        type="postcode",
+        # US ZIP code (5 digit or ZIP+4)
+        pattern=re.compile(r"\b[0-9]{5}(?:-[0-9]{4})?\b"),
+    ),
+    PiiPattern(
+        id="PII-UKPOST-001",
+        type="postcode",
+        # UK postcode
+        pattern=re.compile(
+            r"\b[A-Z]{1,2}[0-9][0-9A-Z]?\s?[0-9][A-Z]{2}\b", re.IGNORECASE
+        ),
+    ),
+    PiiPattern(
+        id="PII-CAPOST-001",
+        type="postcode",
+        # Canadian postal code: A1A 1A1
+        pattern=re.compile(
+            r"\b[A-CEGHJKLMNPRSTVXYa-cegjklmnprstvxy][0-9][A-Za-z]\s?[0-9][A-Za-z][0-9]\b"
+        ),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Canadian SIN
+# ---------------------------------------------------------------------------
+
+_SIN_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-SIN-001",
+        type="other",
+        # Canadian Social Insurance Number: NNN NNN NNN (first digit 1-9, not 0)
+        pattern=re.compile(r"\b[1-9][0-9]{2}[\s\-][0-9]{3}[\s\-][0-9]{3}\b"),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Passport Numbers
+# ---------------------------------------------------------------------------
+
+_PASSPORT_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-PASSPORT-US-001",
+        type="passport",
+        # US Passport: 9 digits (newer) or letter + 8 digits
+        pattern=re.compile(r"\b(?:[A-Z][0-9]{8}|[0-9]{9})\b"),
+    ),
+    PiiPattern(
+        id="PII-PASSPORT-UK-001",
+        type="passport",
+        # UK Passport: 9 digits
+        pattern=re.compile(r"\b[0-9]{9}\b"),
+    ),
+    PiiPattern(
+        id="PII-PASSPORT-GENERIC-001",
+        type="passport",
+        # Generic MRZ-style: 2 letters + 6 alphanumeric
+        pattern=re.compile(r"\b[A-Z]{2}[A-Z0-9]{6,7}\b"),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Date of Birth
+# ---------------------------------------------------------------------------
+
+_DOB_PATTERNS: list[PiiPattern] = [
+    PiiPattern(
+        id="PII-DOB-001",
+        type="dob",
+        # ISO format: YYYY-MM-DD
+        pattern=re.compile(
+            r"\b(?:19|20)[0-9]{2}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])\b"
+        ),
+    ),
+    PiiPattern(
+        id="PII-DOB-002",
+        type="dob",
+        # US format: MM/DD/YYYY
+        pattern=re.compile(
+            r"\b(?:0[1-9]|1[0-2])\/(?:0[1-9]|[12][0-9]|3[01])\/(?:19|20)[0-9]{2}\b"
+        ),
+    ),
+    PiiPattern(
+        id="PII-DOB-003",
+        type="dob",
+        # EU format: DD.MM.YYYY
+        pattern=re.compile(
+            r"\b(?:0[1-9]|[12][0-9]|3[01])\.(?:0[1-9]|1[0-2])\.(?:19|20)[0-9]{2}\b"
+        ),
+    ),
+    PiiPattern(
+        id="PII-DOB-004",
+        type="dob",
+        # Written "born on", "date of birth", "dob" keyword patterns
+        pattern=re.compile(
+            r"(?:born(?:\s+on)?|date\s+of\s+birth|dob)\s*[:\-]?\s*"
+            r"(?:0?[1-9]|[12][0-9]|3[01])[\s\/\-](?:0?[1-9]|1[0-2])[\s\/\-](?:19|20)[0-9]{2}",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Aggregate export
+# ---------------------------------------------------------------------------
+
+PII_PATTERNS: list[PiiPattern] = [
+    *_EMAIL_PATTERNS,
+    *_PHONE_PATTERNS,
+    *_SSN_PATTERNS,
+    *_CREDIT_CARD_PATTERNS,
+    *_IBAN_PATTERNS,
+    *_IP_PATTERNS,
+    *_MAC_PATTERNS,
+    *_POSTCODE_PATTERNS,
+    *_SIN_PATTERNS,
+    *_PASSPORT_PATTERNS,
+    *_DOB_PATTERNS,
+]
+"""All built-in PII detection patterns. 27 patterns covering email, phone, SSN,
+credit card, IBAN, IP, MAC, postcodes, passports, and dates of birth."""
+
+__all__ = ["PiiPattern", "PiiType", "PII_PATTERNS", "luhn_check", "iban_check"]

--- a/packages/py/glin_profanity/scanners/patterns/secret_patterns.py
+++ b/packages/py/glin_profanity/scanners/patterns/secret_patterns.py
@@ -1,0 +1,1052 @@
+"""
+Secret detection patterns for the SecretsScanner.
+
+Pattern attribution:
+  - ProtectAI/llm-guard (MIT) — https://github.com/protectai/llm-guard
+  - Yelp/detect-secrets (Apache-2.0) — https://github.com/Yelp/detect-secrets
+
+Patterns have been reimplemented in Python — no source was copied verbatim.
+
+Mirrors packages/js/src/scanners/patterns/secret-patterns.ts.
+
+@module scanners/patterns/secret_patterns
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+SecretSeverity = Literal["low", "medium", "high", "critical"]
+
+
+@dataclass
+class SecretPattern:
+    """A single secret detection rule."""
+
+    id: str
+    """Unique identifier, e.g. 'SEC-AWS-001'."""
+
+    name: str
+    """Human-readable name shown in scan results."""
+
+    pattern: re.Pattern[str]
+    """Compiled regular expression for detection."""
+
+    severity: SecretSeverity
+    """Severity of exposure if this secret is leaked."""
+
+    family: Optional[str] = None
+    """
+    Short family label used in ScanMatch.category and redaction placeholders,
+    e.g. 'aws', 'stripe', 'github'. When omitted, derived from the id by
+    lowercasing the middle segment (e.g. 'SEC-STRIPE-001' -> 'stripe').
+    """
+
+    entropy_check: bool = False
+    """
+    When True, also require Shannon entropy > 4.0 on the matched token
+    before flagging. Reduces false-positives on placeholder/example strings.
+    """
+
+
+# ---------------------------------------------------------------------------
+# AWS
+# ---------------------------------------------------------------------------
+
+_AWS_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-AWS-001",
+        name="AWS Access Key ID",
+        # AWS access keys are exactly AKIA + 16 uppercase alphanumeric chars.
+        # No entropy check: the structural prefix AKIA is sufficient signal.
+        pattern=re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-AWS-002",
+        name="AWS Secret Access Key",
+        pattern=re.compile(
+            r"(?:aws[_\-. ]?secret[_\-. ]?(?:access[_\-. ]?)?key"
+            r"|aws[_\-. ]?(?:secret|priv))['\"\s:=]+([A-Za-z0-9\/+]{40})\b",
+            re.IGNORECASE,
+        ),
+        severity="critical",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-AWS-003",
+        name="AWS Session Token",
+        pattern=re.compile(
+            r"(?:aws[_\-. ]?session[_\-. ]?token)['\"\s:=]+([A-Za-z0-9\/+=]{100,})",
+            re.IGNORECASE,
+        ),
+        severity="critical",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-AWS-004",
+        name="AWS MWS Key",
+        pattern=re.compile(
+            r"amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+            re.IGNORECASE,
+        ),
+        severity="high",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# GCP
+# ---------------------------------------------------------------------------
+
+_GCP_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-GCP-001",
+        name="GCP Service Account Key",
+        pattern=re.compile(r'"private_key":\s*"-----BEGIN (RSA )?PRIVATE KEY-----'),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-GCP-002",
+        name="GCP API Key",
+        pattern=re.compile(r"AIza[0-9A-Za-z\-_]{35}"),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-GCP-003",
+        name="Google OAuth Client Secret",
+        pattern=re.compile(r"GOCSPX-[0-9A-Za-z\-_]{28}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-GCP-004",
+        name="Firebase Server Key",
+        pattern=re.compile(r"AAAA[A-Za-z0-9_-]{7}:[A-Za-z0-9_-]{140}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-GCP-005",
+        name="Firebase Cloud Messaging Key",
+        pattern=re.compile(
+            r"(?:firebase|fcm)[_\-. ]?(?:api[_\-. ]?)?key"
+            r"['\"\s:=]+([A-Za-z0-9_\-]{38,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Azure
+# ---------------------------------------------------------------------------
+
+_AZURE_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-AZ-001",
+        name="Azure Storage Account Key",
+        pattern=re.compile(
+            r"DefaultEndpointsProtocol=https;AccountName=[^;]+;AccountKey=[A-Za-z0-9+\/=]{88}"
+        ),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-AZ-002",
+        name="Azure Connection String",
+        pattern=re.compile(
+            r"(?:azure|az)[_\-. ]?(?:storage)?[_\-. ]?"
+            r"(?:connection[_\-. ]?string|conn[_\-. ]?str)"
+            r"['\"\s:=]+([^'\";\s]{30,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-AZ-003",
+        name="Azure Subscription Key",
+        pattern=re.compile(
+            r"(?:azure|ocp)\-apim\-subscription\-key['\"\s:]+([a-f0-9]{32})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-AZ-004",
+        name="Azure SAS Token",
+        pattern=re.compile(r"sig=[A-Za-z0-9%+\/=]{20,}(&|$)"),
+        severity="high",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# GitHub
+# ---------------------------------------------------------------------------
+
+_GITHUB_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-GH-001",
+        name="GitHub Classic Personal Access Token",
+        # ghp_ followed by 30-40 alphanumeric chars (36 chars after prefix)
+        pattern=re.compile(r"ghp_[0-9A-Za-z]{30,40}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-GH-002",
+        name="GitHub Fine-Grained PAT",
+        # github_pat_ followed by 60+ alphanumeric/underscore chars
+        pattern=re.compile(r"github_pat_[0-9A-Za-z_]{60,}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-GH-003",
+        name="GitHub OAuth Token",
+        pattern=re.compile(r"gho_[0-9A-Za-z]{30,40}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-GH-004",
+        name="GitHub App Token",
+        pattern=re.compile(r"(?:ghu|ghs)_[0-9A-Za-z]{30,40}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-GH-005",
+        name="GitHub Refresh Token",
+        pattern=re.compile(r"ghr_[0-9A-Za-z]{60,}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-GH-006",
+        name="GitHub Actions Secret",
+        pattern=re.compile(
+            r"(?:GITHUB[_\-. ]?TOKEN|GH[_\-. ]?TOKEN)['\"\s:=]+([A-Za-z0-9_\-]{36,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# GitLab
+# ---------------------------------------------------------------------------
+
+_GITLAB_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-GL-001",
+        name="GitLab Personal Access Token",
+        pattern=re.compile(r"glpat-[0-9A-Za-z\-_]{20}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-GL-002",
+        name="GitLab Runner Registration Token",
+        pattern=re.compile(r"GR1348941[0-9A-Za-z\-_]{20}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-GL-003",
+        name="GitLab Deploy Token",
+        pattern=re.compile(r"gldt-[0-9A-Za-z\-_]{20}"),
+        severity="high",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Bitbucket
+# ---------------------------------------------------------------------------
+
+_BITBUCKET_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-BB-001",
+        name="Bitbucket App Password",
+        pattern=re.compile(
+            r"(?:bitbucket)[_\-. ]?(?:app[_\-. ]?)?(?:password|token|key)"
+            r"['\"\s:=]+([A-Za-z0-9+\/]{16,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Slack
+# ---------------------------------------------------------------------------
+
+_SLACK_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-SLACK-001",
+        name="Slack Bot Token",
+        pattern=re.compile(r"xoxb-[0-9]{10,13}-[0-9]{10,13}-[A-Za-z0-9]{23,25}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-SLACK-002",
+        name="Slack User Token",
+        pattern=re.compile(r"xoxp-[0-9]{10,13}-[0-9]{10,13}-[0-9]{10,13}-[A-Za-z0-9]{32}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-SLACK-003",
+        name="Slack Workspace Token",
+        pattern=re.compile(r"xoxa-[0-9]{10,13}-[0-9]{10,13}-[0-9]{10,13}-[A-Za-z0-9]{32}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-SLACK-004",
+        name="Slack Webhook URL",
+        pattern=re.compile(
+            r"https://hooks\.slack\.com/services/T[0-9A-Z]{8,10}/B[0-9A-Z]{8,10}/[A-Za-z0-9]{24,}"
+        ),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-SLACK-005",
+        name="Slack App Token",
+        pattern=re.compile(r"xapp-[0-9]-[A-Z0-9]{10,12}-[0-9]+-[a-f0-9]{64}"),
+        severity="high",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Stripe
+# ---------------------------------------------------------------------------
+
+_STRIPE_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-STRIPE-001",
+        name="Stripe Live Secret Key",
+        pattern=re.compile(r"sk_live_[0-9A-Za-z]{24,99}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-STRIPE-002",
+        name="Stripe Test Secret Key",
+        pattern=re.compile(r"sk_test_[0-9A-Za-z]{24,99}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-STRIPE-003",
+        name="Stripe Restricted Key",
+        pattern=re.compile(r"rk_(?:live|test)_[0-9A-Za-z]{24,}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-STRIPE-004",
+        name="Stripe Publishable Key",
+        pattern=re.compile(r"pk_(?:live|test)_[0-9A-Za-z]{24,}"),
+        severity="medium",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# AI Providers
+# ---------------------------------------------------------------------------
+
+_AI_PROVIDER_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-OPENAI-001",
+        name="OpenAI API Key",
+        pattern=re.compile(r"sk-[A-Za-z0-9]{20}T3BlbkFJ[A-Za-z0-9]{20}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-OPENAI-002",
+        name="OpenAI Project API Key",
+        pattern=re.compile(r"sk-proj-[A-Za-z0-9\-_]{50,}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-ANTHROPIC-001",
+        name="Anthropic API Key",
+        pattern=re.compile(r"sk-ant-(?:api03-)[A-Za-z0-9\-_]{93,}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-ANTHROPIC-002",
+        name="Anthropic API Key (short form)",
+        pattern=re.compile(r"sk-ant-[A-Za-z0-9\-_]{20,}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-HUGGINGFACE-001",
+        name="Hugging Face User Access Token",
+        pattern=re.compile(r"hf_[A-Za-z0-9]{34,}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-COHERE-001",
+        name="Cohere API Key",
+        pattern=re.compile(
+            r"(?:cohere)[_\-. ]?(?:api[_\-. ]?)?key['\"\s:=]+([A-Za-z0-9]{40,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Payment / Fintech
+# ---------------------------------------------------------------------------
+
+_PAYMENT_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-TWILIO-001",
+        name="Twilio Account SID",
+        pattern=re.compile(r"AC[0-9a-f]{32}\b"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-TWILIO-002",
+        name="Twilio Auth Token",
+        pattern=re.compile(
+            r"(?:twilio)[_\-. ]?(?:auth[_\-. ]?)?token['\"\s:=]+([0-9a-f]{32})",
+            re.IGNORECASE,
+        ),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-SG-001",
+        name="SendGrid API Key",
+        # SG. + 20-30 alphanumeric chars + . + 40+ alphanumeric chars
+        pattern=re.compile(r"SG\.[0-9A-Za-z\-_]{20,30}\.[0-9A-Za-z\-_]{40,}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-MG-001",
+        name="Mailgun API Key",
+        pattern=re.compile(r"key-[0-9a-z]{32}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-MG-002",
+        name="Mailgun Webhook Signing Key",
+        pattern=re.compile(
+            r"(?:mailgun)[_\-. ]?(?:webhook[_\-. ]?)?(?:signing[_\-. ]?)?key"
+            r"['\"\s:=]+([A-Za-z0-9_\-]{32,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-BRAINTREE-001",
+        name="Braintree Access Token",
+        pattern=re.compile(r"access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-SQUARE-001",
+        name="Square Access Token",
+        pattern=re.compile(r"sq0atp-[0-9A-Za-z\-_]{22}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-SQUARE-002",
+        name="Square OAuth Secret",
+        pattern=re.compile(r"sq0csp-[0-9A-Za-z\-_]{43}"),
+        severity="critical",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Package Registries
+# ---------------------------------------------------------------------------
+
+_REGISTRY_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-NPM-001",
+        name="npm Access Token",
+        pattern=re.compile(r"npm_[A-Za-z0-9]{36}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-NPM-002",
+        name="npm Legacy Token",
+        pattern=re.compile(r"//registry\.npmjs\.org/:_authToken=[A-Za-z0-9\-_]{36,}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-PYPI-001",
+        name="PyPI Upload Token",
+        pattern=re.compile(r"pypi-AgEIcHlwaS5vcmc[A-Za-z0-9\-_]{50,}"),
+        severity="high",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Cryptographic Keys & Certificates
+# ---------------------------------------------------------------------------
+
+_CRYPTO_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-KEY-001",
+        name="RSA Private Key",
+        pattern=re.compile(r"-----BEGIN RSA PRIVATE KEY-----"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-KEY-002",
+        name="EC Private Key",
+        pattern=re.compile(r"-----BEGIN EC PRIVATE KEY-----"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-KEY-003",
+        name="OpenSSH Private Key",
+        pattern=re.compile(r"-----BEGIN OPENSSH PRIVATE KEY-----"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-KEY-004",
+        name="PGP Private Key Block",
+        pattern=re.compile(r"-----BEGIN PGP PRIVATE KEY BLOCK-----"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-KEY-005",
+        name="Generic PKCS8 Private Key",
+        pattern=re.compile(r"-----BEGIN PRIVATE KEY-----"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-JWT-001",
+        name="JSON Web Token",
+        pattern=re.compile(r"eyJ[A-Za-z0-9\-_=]{10,}\.eyJ[A-Za-z0-9\-_=]{10,}\.[A-Za-z0-9\-_=]{10,}"),
+        severity="high",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Infrastructure / Cloud Platforms
+# ---------------------------------------------------------------------------
+
+_INFRA_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-HEROKU-001",
+        name="Heroku API Key",
+        pattern=re.compile(
+            r"(?:heroku)[_\-. ]?(?:api[_\-. ]?)?key['\"\s:=]+"
+            r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-DO-001",
+        name="DigitalOcean Personal Access Token",
+        pattern=re.compile(r"dop_v1_[a-f0-9]{64}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-DO-002",
+        name="DigitalOcean OAuth Token",
+        pattern=re.compile(r"doo_v1_[a-f0-9]{64}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-DO-003",
+        name="DigitalOcean Spaces Key",
+        pattern=re.compile(
+            r"(?:digitalocean|do)[_\-. ]?spaces[_\-. ]?(?:secret|key)"
+            r"['\"\s:=]+([A-Za-z0-9+\/=]{40,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-SUPABASE-001",
+        name="Supabase Service Role Key",
+        pattern=re.compile(
+            r"eyJ[A-Za-z0-9\-_=]+\.eyJ[A-Za-z0-9\-_=]+\.[A-Za-z0-9\-_.+\/=]+(?=.*supabase)",
+            re.IGNORECASE,
+        ),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-SUPABASE-002",
+        name="Supabase Connection String",
+        pattern=re.compile(
+            r"postgresql://postgres:[A-Za-z0-9!@#$%^&*()_+\-=]{8,}@[a-z0-9.]+\.supabase\.co",
+            re.IGNORECASE,
+        ),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-FIREBASE-001",
+        name="Firebase Admin SDK Credential",
+        pattern=re.compile(r'"type":\s*"service_account"[^}]*"project_id"', re.DOTALL),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-NETLIFY-001",
+        name="Netlify Access Token",
+        pattern=re.compile(
+            r"(?:netlify)[_\-. ]?(?:access[_\-. ]?)?token"
+            r"['\"\s:=]+([A-Za-z0-9_\-]{40,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-VERCEL-001",
+        name="Vercel Token",
+        pattern=re.compile(
+            r"(?:vercel)[_\-. ]?token['\"\s:=]+([A-Za-z0-9_\-]{24,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-RAILWAY-001",
+        name="Railway Token",
+        pattern=re.compile(
+            r"(?:railway)[_\-. ]?token['\"\s:=]+([A-Za-z0-9_\-]{24,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Databases
+# ---------------------------------------------------------------------------
+
+_DATABASE_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-DB-001",
+        name="Generic Database Connection String (with credentials)",
+        pattern=re.compile(
+            r"(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis)://[^:@\s]+:[^@\s]{8,}@[^\s'\"]+",
+            re.IGNORECASE,
+        ),
+        severity="critical",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-DB-002",
+        name="MongoDB Atlas Connection String",
+        pattern=re.compile(
+            r"mongodb\+srv://[A-Za-z0-9]+:[A-Za-z0-9!@#$%^&*()_+\-=]{8,}@cluster",
+            re.IGNORECASE,
+        ),
+        severity="critical",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Developer Tools & CI/CD
+# ---------------------------------------------------------------------------
+
+_DEVTOOLS_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-SENTRY-001",
+        name="Sentry Auth Token",
+        pattern=re.compile(
+            r"(?:sentry)[_\-. ]?(?:auth[_\-. ]?)?token['\"\s:=]+([A-Za-z0-9_\-]{64})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-DD-001",
+        name="Datadog API Key",
+        pattern=re.compile(
+            r"(?:datadog|dd)[_\-. ]?(?:api[_\-. ]?)?key['\"\s:=]+([a-f0-9]{32})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-NEWRELIC-001",
+        name="New Relic License Key",
+        pattern=re.compile(
+            r"(?:new.?relic)[_\-. ]?(?:license[_\-. ]?)?key['\"\s:=]+([A-Za-z0-9]{40})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-JIRA-001",
+        name="Atlassian / Jira API Token",
+        pattern=re.compile(
+            r"(?:atlassian|jira)[_\-. ]?(?:api[_\-. ]?)?token"
+            r"['\"\s:=]+([A-Za-z0-9+\/=]{24,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-VAULT-001",
+        name="HashiCorp Vault Token",
+        pattern=re.compile(r"hvs\.[A-Za-z0-9_\-]{24,}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-VAULT-002",
+        name="HashiCorp Vault Token (legacy)",
+        pattern=re.compile(r"s\.[A-Za-z0-9]{24,}\b"),
+        severity="medium",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-CIRCLECI-001",
+        name="CircleCI Personal API Token",
+        pattern=re.compile(
+            r"(?:circleci)[_\-. ]?(?:api[_\-. ]?)?token['\"\s:=]+([A-Za-z0-9_]{40})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Social / Messaging
+# ---------------------------------------------------------------------------
+
+_SOCIAL_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-DISCORD-001",
+        name="Discord Bot Token",
+        pattern=re.compile(r"[MN][A-Za-z0-9]{23,25}\.[A-Za-z0-9\-_]{6,7}\.[A-Za-z0-9\-_]{27,40}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-DISCORD-002",
+        name="Discord Webhook",
+        pattern=re.compile(
+            r"https://discord(?:app)?\.com/api/webhooks/[0-9]{17,20}/[A-Za-z0-9\-_]{60,}"
+        ),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-TELEGRAM-001",
+        name="Telegram Bot API Token",
+        pattern=re.compile(r"[0-9]{8,10}:AA[A-Za-z0-9\-_]{33}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-TWITTER-001",
+        name="Twitter / X Bearer Token",
+        pattern=re.compile(r"AAAAAAAAAAAAAAAA[A-Za-z0-9%]{40,}"),
+        severity="high",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Search & CMS
+# ---------------------------------------------------------------------------
+
+_SEARCH_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-ALGOLIA-001",
+        name="Algolia API Key",
+        pattern=re.compile(
+            r"(?:algolia)[_\-. ]?(?:api[_\-. ]?)?key['\"\s:=]+([a-f0-9]{32})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-CONTENTFUL-001",
+        name="Contentful Delivery API Token",
+        pattern=re.compile(
+            r"(?:contentful)[_\-. ]?(?:access|delivery|preview)[_\-. ]?token"
+            r"['\"\s:=]+([A-Za-z0-9_\-]{43,})",
+            re.IGNORECASE,
+        ),
+        severity="medium",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-SHOPIFY-001",
+        name="Shopify Private App Password",
+        pattern=re.compile(r"shppa_[A-Za-z0-9]{32}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-SHOPIFY-002",
+        name="Shopify Shared Secret",
+        pattern=re.compile(r"shpss_[A-Za-z0-9]{32}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-SHOPIFY-003",
+        name="Shopify Access Token",
+        pattern=re.compile(r"shpat_[A-Za-z0-9]{32}"),
+        severity="critical",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Docker / Container Registries
+# ---------------------------------------------------------------------------
+
+_CONTAINER_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-DOCKER-001",
+        name="Docker Hub Password (Basic Auth)",
+        pattern=re.compile(
+            r"(?:docker)[_\-. ]?(?:password|token|secret)['\"\s:=]+([^\s'\"]{12,})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-GHCR-001",
+        name="GitHub Container Registry Auth",
+        pattern=re.compile(r"ghcr\.io[^\s]*:[^\s]{20,}"),
+        severity="high",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# High-entropy generic patterns (entropy check required)
+# ---------------------------------------------------------------------------
+
+_GENERIC_ENTROPY_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-GEN-001",
+        name="Generic Password Assignment",
+        pattern=re.compile(
+            r"(?:password|passwd|pwd)\s*[:=]\s*['\"]?([A-Za-z0-9!@#$%^&*()_+\-=]{16,})['\"]?",
+            re.IGNORECASE,
+        ),
+        severity="medium",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-GEN-002",
+        name="Generic Token Assignment",
+        pattern=re.compile(
+            r"(?:token|api.?key|api.?token|access.?token|auth.?token)\s*[:=]\s*['\"]?([A-Za-z0-9+\/\-_]{24,})['\"]?",
+            re.IGNORECASE,
+        ),
+        severity="medium",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-GEN-003",
+        name="Generic Secret Assignment",
+        pattern=re.compile(
+            r"(?:secret|client.?secret|app.?secret)\s*[:=]\s*['\"]?([A-Za-z0-9+\/\-_]{24,})['\"]?",
+            re.IGNORECASE,
+        ),
+        severity="medium",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-GEN-004",
+        name="High-Entropy Base64 (near secret keyword)",
+        pattern=re.compile(
+            r"(?:key|secret|token|password)['\"\s:=]+([A-Za-z0-9+\/]{32,}={0,2})",
+            re.IGNORECASE,
+        ),
+        severity="low",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-GEN-005",
+        name="High-Entropy Hex String (near secret keyword)",
+        pattern=re.compile(
+            r"(?:key|secret|token|password)['\"\s:=]+([a-f0-9]{40,})\b",
+            re.IGNORECASE,
+        ),
+        severity="low",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-GEN-006",
+        name="Authorization Bearer Token in Header",
+        pattern=re.compile(
+            r"Authorization:\s*Bearer\s+([A-Za-z0-9\-_=.]{20,})",
+            re.IGNORECASE,
+        ),
+        severity="medium",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-GEN-007",
+        name="Authorization Basic Header",
+        pattern=re.compile(
+            r"Authorization:\s*Basic\s+([A-Za-z0-9+\/=]{12,})",
+            re.IGNORECASE,
+        ),
+        severity="medium",
+        entropy_check=True,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Additional Providers (Miscellaneous)
+# ---------------------------------------------------------------------------
+
+_MISC_PATTERNS: list[SecretPattern] = [
+    SecretPattern(
+        id="SEC-PLANETSCALE-001",
+        name="PlanetScale Service Token",
+        pattern=re.compile(r"pscale_tkn_[A-Za-z0-9]{32}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-PLANETSCALE-002",
+        name="PlanetScale OAuth Token",
+        pattern=re.compile(r"pscale_oauth_[A-Za-z0-9]{32}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-LINEAR-001",
+        name="Linear API Key",
+        pattern=re.compile(r"lin_api_[A-Za-z0-9]{40}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-AIRTABLE-001",
+        name="Airtable API Key (legacy)",
+        pattern=re.compile(r"key[A-Za-z0-9]{14}\b"),
+        severity="medium",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-AIRTABLE-002",
+        name="Airtable Personal Access Token",
+        pattern=re.compile(r"pat[A-Za-z0-9]{14}\.[A-Za-z0-9]{64}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-MAPBOX-001",
+        name="Mapbox Access Token",
+        pattern=re.compile(r"pk\.eyJ1[A-Za-z0-9\-_=.]+"),
+        severity="medium",
+    ),
+    SecretPattern(
+        id="SEC-MAPBOX-002",
+        name="Mapbox Secret Token",
+        pattern=re.compile(r"sk\.eyJ1[A-Za-z0-9\-_=.]+"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-DOPPLER-001",
+        name="Doppler Service Token",
+        pattern=re.compile(r"dp\.st\.[A-Za-z0-9_\-]{43}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-DOPPLER-002",
+        name="Doppler Personal Token",
+        pattern=re.compile(r"dp\.pt\.[A-Za-z0-9_\-]{43}"),
+        severity="critical",
+    ),
+    SecretPattern(
+        id="SEC-LAUNCHDARKLY-001",
+        name="LaunchDarkly SDK Key",
+        pattern=re.compile(r"sdk-[A-Za-z0-9\-_]{40}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-POSTMAN-001",
+        name="Postman API Key",
+        pattern=re.compile(r"PMAK-[0-9a-f]{24}-[0-9a-f]{34}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-OKTA-001",
+        name="Okta API Token",
+        pattern=re.compile(r"00[A-Za-z0-9\-_]{40}"),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-ZENDESK-001",
+        name="Zendesk Secret Key",
+        pattern=re.compile(
+            r"(?:zendesk)[_\-. ]?(?:secret|token|key)['\"\s:=]+([A-Za-z0-9]{40})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+        entropy_check=True,
+    ),
+    SecretPattern(
+        id="SEC-TYPEFORM-001",
+        name="Typeform Personal Access Token",
+        pattern=re.compile(r"tfp_[A-Za-z0-9_\-]{40,}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-GRAFANA-001",
+        name="Grafana API Key",
+        pattern=re.compile(r"eyJrIjoi[A-Za-z0-9\-_=]{40,}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-PULUMI-001",
+        name="Pulumi Access Token",
+        pattern=re.compile(r"pul-[A-Za-z0-9]{40}"),
+        severity="high",
+    ),
+    SecretPattern(
+        id="SEC-CODECOV-001",
+        name="Codecov Upload Token",
+        pattern=re.compile(
+            r"(?:codecov)[_\-. ]?token['\"\s:=]+([a-f0-9]{32})",
+            re.IGNORECASE,
+        ),
+        severity="medium",
+    ),
+    SecretPattern(
+        id="SEC-SNYK-001",
+        name="Snyk API Token",
+        pattern=re.compile(
+            r"(?:snyk)[_\-. ]?(?:api[_\-. ]?)?token['\"\s:=]+([a-f0-9-]{36})",
+            re.IGNORECASE,
+        ),
+        severity="high",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Aggregate export
+# ---------------------------------------------------------------------------
+
+SECRET_PATTERNS: list[SecretPattern] = [
+    *_AWS_PATTERNS,
+    *_GCP_PATTERNS,
+    *_AZURE_PATTERNS,
+    *_GITHUB_PATTERNS,
+    *_GITLAB_PATTERNS,
+    *_BITBUCKET_PATTERNS,
+    *_SLACK_PATTERNS,
+    *_STRIPE_PATTERNS,
+    *_AI_PROVIDER_PATTERNS,
+    *_PAYMENT_PATTERNS,
+    *_REGISTRY_PATTERNS,
+    *_CRYPTO_PATTERNS,
+    *_INFRA_PATTERNS,
+    *_DATABASE_PATTERNS,
+    *_DEVTOOLS_PATTERNS,
+    *_SOCIAL_PATTERNS,
+    *_SEARCH_PATTERNS,
+    *_CONTAINER_PATTERNS,
+    *_GENERIC_ENTROPY_PATTERNS,
+    *_MISC_PATTERNS,
+]
+"""All built-in secret detection patterns.
+
+110 patterns covering major cloud/SaaS providers.
+"""
+
+__all__ = ["SecretPattern", "SecretSeverity", "SECRET_PATTERNS"]

--- a/packages/py/glin_profanity/scanners/pii.py
+++ b/packages/py/glin_profanity/scanners/pii.py
@@ -1,0 +1,215 @@
+"""
+PII scanner — detects Personally Identifiable Information in text.
+
+Mirrors packages/js/src/scanners/pii.ts.
+
+@module scanners/pii
+"""
+
+from typing import Optional
+
+from .base import ScanMatch, ScanResult, allow_result, block_result
+from .patterns.pii_patterns import PII_PATTERNS, PiiPattern
+from .vault import Vault
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _deduplicate_matches(matches: list[ScanMatch]) -> list[ScanMatch]:
+    """
+    Remove overlapping/duplicate match ranges.
+    When two matches overlap, keep the one with the larger span.
+    Sort by start_index ascending; for equal start_index, put larger spans first.
+    """
+    sorted_matches = sorted(matches, key=lambda m: (m.start_index, -m.end_index))
+    result: list[ScanMatch] = []
+    last_end = -1
+
+    for m in sorted_matches:
+        if m.start_index >= last_end:
+            # Non-overlapping: keep this match.
+            result.append(m)
+            last_end = m.end_index
+        elif m.end_index > last_end and result:
+            # This match overlaps the previous but extends further — replace it.
+            result[-1] = m
+            last_end = m.end_index
+        # Otherwise the current match is fully contained in the previous — skip it.
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# PiiScanner
+# ---------------------------------------------------------------------------
+
+
+class PiiScanner:
+    """
+    Scanner that detects PII (email, phone, SSN, credit card, IBAN, IP, MAC,
+    postcodes, passports, and dates of birth) in text.
+
+    Implements the unified Scanner interface.
+    """
+
+    name = "pii"
+
+    def __init__(
+        self,
+        redact: bool = False,
+        vault: Optional[Vault] = None,
+        custom_patterns: Optional[list[PiiPattern]] = None,
+        block_on_any: bool = True,
+        block_at: float = 0.8,
+        hitl_at: float = 0.5,
+    ) -> None:
+        """
+        Initialise the scanner.
+
+        Args:
+            redact: When True, replace detected PII with vault placeholders
+                in ScanResult.sanitized. Requires vault to also be provided.
+            vault: Vault instance used to store originals when redact is True.
+            custom_patterns: Extra patterns merged with the built-in set.
+            block_on_any: When True (default), any detected PII causes a BLOCK
+                decision. When False, the scanner will score proportionally.
+            block_at: Score threshold for BLOCK decision (default: 0.8).
+            hitl_at: Score threshold for HITL decision (default: 0.5).
+        """
+        self._patterns: list[PiiPattern] = [*PII_PATTERNS, *(custom_patterns or [])]
+        self._redact = redact
+        self._vault = vault
+        self._block_on_any = block_on_any
+        self._block_at = block_at
+        self._hitl_at = hitl_at
+
+    def scan(self, input: str, ctx: Optional[dict] = None) -> ScanResult:  # noqa: A002
+        """
+        Evaluate the input string for PII.
+
+        Args:
+            input: The text to scan.
+            ctx: Optional context dict (reserved for future use).
+
+        Returns:
+            A ScanResult with decision, score, and match details.
+        """
+        matches: list[ScanMatch] = []
+        reasons: list[str] = []
+
+        for entry in self._patterns:
+            for m in entry.pattern.finditer(input):
+                matched = m.group(0)
+
+                # Run optional validator (e.g. Luhn, IBAN mod-97)
+                if entry.validator is not None and not entry.validator(matched):
+                    continue
+
+                matches.append(
+                    ScanMatch(
+                        pattern=entry.id,
+                        start_index=m.start(),
+                        end_index=m.end(),
+                        category=entry.type,
+                    )
+                )
+
+                label = f"{entry.type.upper()} ({entry.id})"
+                if label not in reasons:
+                    reasons.append(label)
+
+        if not matches:
+            return allow_result(self.name, input)
+
+        # Redact if requested
+        sanitized = input
+        if self._redact:
+            sanitized = self._redact_input(input, matches)
+
+        score = 1.0 if self._block_on_any else min(1.0, len(matches) / 5)
+
+        result = block_result(
+            self.name,
+            sanitized,
+            score,
+            reasons,
+            matches,
+            self._block_at,
+            self._hitl_at,
+        )
+
+        return ScanResult(
+            sanitized=sanitized,
+            valid=result.valid,
+            score=result.score,
+            decision=result.decision,
+            reasons=result.reasons,
+            matches=result.matches,
+            scanner=result.scanner,
+        )
+
+    def _redact_input(self, input: str, matches: list[ScanMatch]) -> str:  # noqa: A002
+        """
+        Replace matched spans in input with vault placeholders.
+        Deduplicates by range then sorts descending so we splice from end.
+        """
+        deduped = _deduplicate_matches(matches)
+        # Sort descending by start_index so we can splice from end without index drift
+        sorted_desc = sorted(deduped, key=lambda m: -m.start_index)
+
+        result = input
+        for m in sorted_desc:
+            original = input[m.start_index : m.end_index]
+            type_label = m.category.upper()
+            placeholder = (
+                self._vault.store(type_label, original)
+                if self._vault is not None
+                else f"[REDACTED_{type_label}]"
+            )
+            result = result[: m.start_index] + placeholder + result[m.end_index :]
+
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Convenience function
+# ---------------------------------------------------------------------------
+
+
+def scan_pii(
+    input: str,  # noqa: A002
+    redact: bool = False,
+    vault: Optional[Vault] = None,
+    custom_patterns: Optional[list[PiiPattern]] = None,
+    block_on_any: bool = True,
+    block_at: float = 0.8,
+    hitl_at: float = 0.5,
+) -> ScanResult:
+    """
+    Scan a single string for PII using configurable options.
+
+    Args:
+        input: The text to scan.
+        redact: Replace detected PII with placeholders.
+        vault: Vault for reversible redaction.
+        custom_patterns: Extra patterns to check.
+        block_on_any: Block on any match (default True).
+        block_at: BLOCK threshold (default 0.8).
+        hitl_at: HITL threshold (default 0.5).
+
+    Returns:
+        A ScanResult with decision, score, and match details.
+    """
+    return PiiScanner(
+        redact=redact,
+        vault=vault,
+        custom_patterns=custom_patterns,
+        block_on_any=block_on_any,
+        block_at=block_at,
+        hitl_at=hitl_at,
+    ).scan(input)
+
+
+__all__ = ["PiiScanner", "scan_pii"]

--- a/packages/py/glin_profanity/scanners/secrets.py
+++ b/packages/py/glin_profanity/scanners/secrets.py
@@ -1,0 +1,267 @@
+"""
+Secrets scanner — detects leaked credentials, API keys, and tokens.
+
+Mirrors packages/js/src/scanners/secrets.ts.
+
+@module scanners/secrets
+"""
+
+import math
+from typing import Optional
+
+from .base import ScanMatch, ScanResult, allow_result, block_result
+from .patterns.secret_patterns import SECRET_PATTERNS, SecretPattern
+from .vault import Vault
+
+# ---------------------------------------------------------------------------
+# Shannon entropy
+# ---------------------------------------------------------------------------
+
+
+def _shannon_entropy(s: str) -> float:
+    """
+    Compute Shannon entropy (base-2) of a string.
+    Returns a value in [0, log2(alphabet_size)].
+    """
+    if not s:
+        return 0.0
+    freq: dict[str, int] = {}
+    for ch in s:
+        freq[ch] = freq.get(ch, 0) + 1
+    entropy = 0.0
+    for count in freq.values():
+        p = count / len(s)
+        entropy -= p * math.log2(p)
+    return entropy
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _secret_family(id: str) -> str:
+    """
+    Derive a short family label from a pattern id.
+    e.g. 'SEC-STRIPE-001' -> 'stripe', 'SEC-AWS-001' -> 'aws'
+    """
+    parts = id.split("-")
+    # id format is 'SEC-<FAMILY>-<NUM>' — middle segment(s) form the family
+    if len(parts) >= 3:
+        return "_".join(parts[1 : len(parts) - 1]).lower()
+    return id.lower()
+
+
+def _deduplicate_matches(matches: list[ScanMatch]) -> list[ScanMatch]:
+    """
+    Remove overlapping/duplicate match ranges.
+    Sorts by start_index ascending, end_index descending (largest span first on tie).
+    Keeps the widest non-overlapping match for each region.
+    """
+    sorted_matches = sorted(matches, key=lambda m: (m.start_index, -m.end_index))
+    result: list[ScanMatch] = []
+    last_end = -1
+
+    for m in sorted_matches:
+        if m.start_index >= last_end:
+            result.append(m)
+            last_end = m.end_index
+        elif m.end_index > last_end and result:
+            # Current match extends beyond the last kept match — replace it
+            result[-1] = m
+            last_end = m.end_index
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# SecretsScanner
+# ---------------------------------------------------------------------------
+
+
+class SecretsScanner:
+    """
+    Scanner that detects secrets, API keys, and credentials in text.
+
+    Implements the unified Scanner interface.
+    """
+
+    name = "secrets"
+
+    def __init__(
+        self,
+        redact: bool = False,
+        vault: Optional[Vault] = None,
+        custom_patterns: Optional[list[SecretPattern]] = None,
+        min_entropy: float = 4.0,
+        block_on_any: bool = True,
+        block_at: float = 0.8,
+        hitl_at: float = 0.5,
+    ) -> None:
+        """
+        Initialise the scanner.
+
+        Args:
+            redact: When True, replace detected secrets with vault placeholders
+                in ScanResult.sanitized. Requires vault to also be provided.
+            vault: Vault instance used to store originals when redact is True.
+                If redact is True but no vault is provided, each detected secret is
+                replaced with the generic string '[REDACTED]' and cannot be restored.
+            custom_patterns: Extra patterns merged with the built-in set.
+            min_entropy: Minimum Shannon entropy required for patterns with
+                entropy_check=True. Default: 4.0.
+            block_on_any: When True (default), any detected secret causes a BLOCK
+                decision. When False, the scanner will score proportionally.
+            block_at: Score threshold for BLOCK decision (default: 0.8).
+            hitl_at: Score threshold for HITL decision (default: 0.5).
+        """
+        self._patterns: list[SecretPattern] = [
+            *SECRET_PATTERNS,
+            *(custom_patterns or []),
+        ]
+        self._redact = redact
+        self._vault = vault
+        self._min_entropy = min_entropy
+        self._block_on_any = block_on_any
+        self._block_at = block_at
+        self._hitl_at = hitl_at
+
+    def scan(self, input: str, ctx: Optional[dict] = None) -> ScanResult:  # noqa: A002
+        """
+        Evaluate the input string for secrets.
+
+        Args:
+            input: The text to scan.
+            ctx: Optional context dict (reserved for future use).
+
+        Returns:
+            A ScanResult with decision, score, and match details.
+        """
+        matches: list[ScanMatch] = []
+        reasons: list[str] = []
+
+        for entry in self._patterns:
+            for m in entry.pattern.finditer(input):
+                # For patterns with capture groups, prefer group 1 for entropy check
+                token = m.group(1) if m.lastindex and m.lastindex >= 1 else m.group(0)
+
+                if entry.entropy_check:
+                    entropy = _shannon_entropy(token)
+                    if entropy < self._min_entropy:
+                        continue
+
+                family = (
+                    entry.family
+                    if entry.family is not None
+                    else _secret_family(entry.id)
+                )
+                matches.append(
+                    ScanMatch(
+                        pattern=entry.id,
+                        start_index=m.start(),
+                        end_index=m.end(),
+                        # category carries the pattern family, not severity
+                        category=family,
+                    )
+                )
+
+                if entry.name not in reasons:
+                    reasons.append(entry.name)
+
+        if not matches:
+            return allow_result(self.name, input)
+
+        # Redact if requested
+        sanitized = input
+        if self._redact:
+            sanitized = self._redact_input(input, matches)
+
+        score = 1.0 if self._block_on_any else min(1.0, len(matches) / 5)
+
+        result = block_result(
+            self.name,
+            sanitized,
+            score,
+            reasons,
+            matches,
+            self._block_at,
+            self._hitl_at,
+        )
+        # block_result sets sanitized to input — override with our redacted version
+        return ScanResult(
+            sanitized=sanitized,
+            valid=result.valid,
+            score=result.score,
+            decision=result.decision,
+            reasons=result.reasons,
+            matches=result.matches,
+            scanner=result.scanner,
+        )
+
+    def _redact_input(self, input: str, matches: list[ScanMatch]) -> str:  # noqa: A002
+        """
+        Replace matched spans in input with vault placeholders.
+        Deduplicates overlapping ranges and splices from highest end down
+        so earlier indices stay valid.
+        """
+        deduped = _deduplicate_matches(matches)
+        # Sort descending by end_index so we splice from end without index drift
+        sorted_desc = sorted(deduped, key=lambda m: (-m.end_index, -m.start_index))
+
+        result = input
+        for m in sorted_desc:
+            original = input[m.start_index : m.end_index]
+            type_label = m.category.upper()
+            placeholder = (
+                self._vault.store(type_label, original)
+                if self._vault is not None
+                else "[REDACTED]"
+            )
+            result = result[: m.start_index] + placeholder + result[m.end_index :]
+
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Convenience function
+# ---------------------------------------------------------------------------
+
+
+def scan_secrets(
+    input: str,  # noqa: A002
+    redact: bool = False,
+    vault: Optional[Vault] = None,
+    custom_patterns: Optional[list[SecretPattern]] = None,
+    min_entropy: float = 4.0,
+    block_on_any: bool = True,
+    block_at: float = 0.8,
+    hitl_at: float = 0.5,
+) -> ScanResult:
+    """
+    Scan a single string for secrets using configurable options.
+
+    Args:
+        input: The text to scan.
+        redact: Replace detected secrets with placeholders.
+        vault: Vault for reversible redaction.
+        custom_patterns: Extra patterns to check.
+        min_entropy: Minimum entropy for entropy-gated patterns.
+        block_on_any: Block on any match (default True).
+        block_at: BLOCK threshold (default 0.8).
+        hitl_at: HITL threshold (default 0.5).
+
+    Returns:
+        A ScanResult with decision, score, and match details.
+    """
+    return SecretsScanner(
+        redact=redact,
+        vault=vault,
+        custom_patterns=custom_patterns,
+        min_entropy=min_entropy,
+        block_on_any=block_on_any,
+        block_at=block_at,
+        hitl_at=hitl_at,
+    ).scan(input)
+
+
+__all__ = ["SecretsScanner", "scan_secrets"]

--- a/packages/py/glin_profanity/scanners/vault.py
+++ b/packages/py/glin_profanity/scanners/vault.py
@@ -1,0 +1,198 @@
+"""
+Vault — stores redacted originals and restores them after pipeline processing.
+
+Design ported from ProtectAI/llm-guard (MIT) — rewritten in Python.
+Supports four restore strategies: exact, case_insensitive, fuzzy, combined.
+
+Mirrors packages/js/src/scanners/vault.ts.
+
+@module scanners/vault
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+RestoreStrategy = Literal["exact", "case_insensitive", "fuzzy", "combined"]
+
+
+@dataclass
+class _VaultEntry:
+    """A single entry stored in the vault."""
+
+    placeholder: str
+    """Placeholder token used in sanitized text, e.g. '[REDACTED_EMAIL_1]'."""
+
+    original: str
+    """The original sensitive value."""
+
+    type: str
+    """Type string, e.g. 'EMAIL', used in placeholder construction."""
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """
+    Levenshtein edit distance between two strings.
+    Used by the fuzzy restore strategy (tolerance <= 3).
+    """
+    m = len(a)
+    n = len(b)
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(m + 1):
+        dp[i][0] = i
+    for j in range(n + 1):
+        dp[0][j] = j
+
+    for i in range(1, m + 1):
+        for j in range(1, n + 1):
+            if a[i - 1] == b[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1]
+            else:
+                dp[i][j] = 1 + min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+
+    return dp[m][n]
+
+
+def _escape_regex(s: str) -> str:
+    """Escape a string for use inside a compiled regex."""
+    return re.escape(s)
+
+
+def _fuzzy_replace(text: str, needle: str, replacement: str, tolerance: int) -> str:
+    """
+    Perform a fuzzy replacement in text, substituting needle with replacement
+    whenever a window of the same length as needle has Levenshtein distance
+    <= tolerance.
+
+    Complexity: O(|text| * |needle|^2) — acceptable for typical prompt sizes.
+    """
+    if not needle:
+        return text
+
+    n = len(needle)
+    result_parts: list[str] = []
+    i = 0
+
+    while i < len(text):
+        window = text[i : i + n]
+        if len(window) < max(1, n // 2):
+            # Too short for meaningful fuzzy match
+            result_parts.append(text[i:])
+            break
+
+        # Fast-path: if the window's first character differs from needle's first
+        # character, skip the full DP — saves O(n^2) work per position.
+        if window[0] != needle[0]:
+            result_parts.append(text[i])
+            i += 1
+            continue
+
+        dist = _levenshtein(window, needle)
+        if dist <= tolerance:
+            result_parts.append(replacement)
+            i += len(window)
+        else:
+            result_parts.append(text[i])
+            i += 1
+
+    return "".join(result_parts)
+
+
+class Vault:
+    """
+    Vault stores placeholder->original mappings produced during redaction and
+    replaces placeholders with originals when text leaves the pipeline.
+
+    Inspired by ProtectAI/llm-guard vault.py (MIT).
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[_VaultEntry] = []
+        self._counters: dict[str, int] = {}
+
+    def store(self, type: str, original: str) -> str:
+        """
+        Store an original value and return a unique placeholder string.
+
+        Args:
+            type: PII/secret type label (will be upper-cased), e.g. 'email'.
+            original: The raw sensitive value to redact.
+
+        Returns:
+            The placeholder token, e.g. '[REDACTED_EMAIL_1]'.
+        """
+        normalized_type = re.sub(r"[^A-Z0-9]", "_", type.upper())
+        count = self._counters.get(normalized_type, 0) + 1
+        self._counters[normalized_type] = count
+        placeholder = f"[REDACTED_{normalized_type}_{count}]"
+        self._entries.append(
+            _VaultEntry(
+                placeholder=placeholder, original=original, type=normalized_type
+            )
+        )
+        return placeholder
+
+    def restore(self, text: str, strategy: RestoreStrategy = "exact") -> str:
+        """
+        Replace all placeholders in text with their original values.
+
+        Args:
+            text: The sanitized text containing placeholder tokens.
+            strategy: How to match placeholders (default: 'exact').
+
+        Returns:
+            The restored text with originals substituted back.
+        """
+        result = text
+
+        for entry in self._entries:
+            if strategy == "exact":
+                result = result.replace(entry.placeholder, entry.original)
+
+            elif strategy == "case_insensitive":
+                # Find all case-insensitive occurrences and replace using split/join
+                ci_re = re.compile(_escape_regex(entry.placeholder), re.IGNORECASE)
+                parts = ci_re.split(result)
+                result = entry.original.join(parts)
+
+            elif strategy == "fuzzy":
+                result = _fuzzy_replace(result, entry.placeholder, entry.original, 3)
+
+            elif strategy == "combined":
+                # Try exact first, then case-insensitive, then fuzzy
+                if entry.placeholder in result:
+                    result = result.replace(entry.placeholder, entry.original)
+                else:
+                    ci_pattern = re.compile(
+                        _escape_regex(entry.placeholder), re.IGNORECASE
+                    )
+                    if ci_pattern.search(result):
+                        result = ci_pattern.sub(entry.original, result)
+                    else:
+                        result = _fuzzy_replace(
+                            result, entry.placeholder, entry.original, 3
+                        )
+
+        return result
+
+    def clear(self) -> None:
+        """Remove all stored entries and reset counters."""
+        self._entries = []
+        self._counters = {}
+
+    def size(self) -> int:
+        """Number of entries currently stored."""
+        return len(self._entries)
+
+    def get_entries(self) -> list[dict[str, str]]:
+        """
+        Retrieve a snapshot of all current entries (read-only copy).
+        Useful for serialisation or inspection.
+        """
+        return [
+            {"placeholder": e.placeholder, "original": e.original, "type": e.type}
+            for e in self._entries
+        ]
+
+
+__all__ = ["Vault", "RestoreStrategy"]

--- a/packages/py/tests/scanners/test_pii.py
+++ b/packages/py/tests/scanners/test_pii.py
@@ -1,0 +1,263 @@
+"""
+Tests for PiiScanner — ported from JS pii.test.ts on release.
+"""
+
+import pytest
+
+from glin_profanity.scanners.base import ScanDecision
+from glin_profanity.scanners.patterns.pii_patterns import iban_check, luhn_check
+from glin_profanity.scanners.pii import PiiScanner, scan_pii
+from glin_profanity.scanners.vault import Vault
+
+
+# ---------------------------------------------------------------------------
+# Email
+# ---------------------------------------------------------------------------
+
+
+class TestPiiEmail:
+    def test_email_detected(self) -> None:
+        result = scan_pii("Contact me at user@example.com please.")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "PII-EMAIL-001" for m in result.matches)
+        match = next(m for m in result.matches if m.pattern == "PII-EMAIL-001")
+        assert match.category == "email"
+
+    def test_email_match_span(self) -> None:
+        text = "Email: test@example.com end"
+        result = scan_pii(text)
+        m = next(m for m in result.matches if m.pattern == "PII-EMAIL-001")
+        assert text[m.start_index : m.end_index] == "test@example.com"
+
+    def test_no_email_allows(self) -> None:
+        result = scan_pii("Hello world, no PII here.")
+        assert result.decision == ScanDecision.ALLOW
+
+
+# ---------------------------------------------------------------------------
+# Phone
+# ---------------------------------------------------------------------------
+
+
+class TestPiiPhone:
+    def test_e164_phone_detected(self) -> None:
+        result = scan_pii("Call me at +14155552671.")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "PII-PHONE-001" for m in result.matches)
+
+    def test_us_nanp_phone_detected(self) -> None:
+        result = scan_pii("My number is (415) 555-2671.")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "PII-PHONE-002" for m in result.matches)
+
+
+# ---------------------------------------------------------------------------
+# SSN
+# ---------------------------------------------------------------------------
+
+
+class TestPiiSsn:
+    def test_ssn_detected(self) -> None:
+        result = scan_pii("SSN: 123-45-6789")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "PII-SSN-001" for m in result.matches)
+        match = next(m for m in result.matches if m.pattern == "PII-SSN-001")
+        assert match.category == "ssn"
+
+    def test_invalid_ssn_group_000_not_detected(self) -> None:
+        # SSN starting with 000 is invalid
+        result = scan_pii("bad: 000-45-6789")
+        ssn_matches = [m for m in result.matches if m.pattern == "PII-SSN-001"]
+        assert len(ssn_matches) == 0
+
+    def test_invalid_ssn_area_666_not_detected(self) -> None:
+        result = scan_pii("bad: 666-45-6789")
+        ssn_matches = [m for m in result.matches if m.pattern == "PII-SSN-001"]
+        assert len(ssn_matches) == 0
+
+
+# ---------------------------------------------------------------------------
+# Credit Card (Luhn validation)
+# ---------------------------------------------------------------------------
+
+
+class TestPiiCreditCard:
+    def test_valid_visa_detected(self) -> None:
+        # Luhn-valid Visa test card
+        result = scan_pii("Card: 4111 1111 1111 1111")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.category == "credit_card" for m in result.matches)
+
+    def test_invalid_luhn_not_detected(self) -> None:
+        # 4111 1111 1111 1112 — fails Luhn check
+        result = scan_pii("Card: 4111 1111 1111 1112")
+        cc_matches = [m for m in result.matches if m.category == "credit_card"]
+        assert len(cc_matches) == 0
+
+    def test_luhn_check_valid(self) -> None:
+        assert luhn_check("4111 1111 1111 1111") is True
+
+    def test_luhn_check_invalid(self) -> None:
+        assert luhn_check("4111 1111 1111 1112") is False
+
+    def test_luhn_check_amex(self) -> None:
+        # Valid Amex test number
+        assert luhn_check("378282246310005") is True
+
+    def test_luhn_check_mastercard(self) -> None:
+        # Valid Mastercard test number
+        assert luhn_check("5500005555555559") is True
+
+    def test_visa_no_spaces(self) -> None:
+        result = scan_pii("4111111111111111")
+        assert result.decision == ScanDecision.BLOCK
+
+    def test_visa_with_dashes(self) -> None:
+        result = scan_pii("4111-1111-1111-1111")
+        assert result.decision == ScanDecision.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# IBAN
+# ---------------------------------------------------------------------------
+
+
+class TestPiiIban:
+    def test_valid_iban_detected(self) -> None:
+        # Valid German IBAN (mod-97 checksum is correct)
+        iban = "DE89370400440532013000"
+        result = scan_pii(f"IBAN: {iban}")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.category == "iban" for m in result.matches)
+
+    def test_invalid_iban_checksum_not_detected(self) -> None:
+        # Wrong check digits
+        result = scan_pii("IBAN: DE00370400440532013000")
+        iban_matches = [m for m in result.matches if m.category == "iban"]
+        assert len(iban_matches) == 0
+
+    def test_iban_check_valid_de(self) -> None:
+        assert iban_check("DE89370400440532013000") is True
+
+    def test_iban_check_valid_gb(self) -> None:
+        # Valid UK IBAN
+        assert iban_check("GB29NWBK60161331926819") is True
+
+    def test_iban_check_invalid_checksum(self) -> None:
+        assert iban_check("DE00370400440532013000") is False
+
+    def test_iban_check_with_spaces(self) -> None:
+        # IBAN in printed format
+        assert iban_check("DE89 3704 0044 0532 0130 00") is True
+
+
+# ---------------------------------------------------------------------------
+# IP Addresses
+# ---------------------------------------------------------------------------
+
+
+class TestPiiIp:
+    def test_ipv4_detected(self) -> None:
+        result = scan_pii("Server at 192.168.1.1 is up.")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "PII-IPV4-001" for m in result.matches)
+        match = next(m for m in result.matches if m.pattern == "PII-IPV4-001")
+        assert match.category == "ip"
+
+    def test_ipv4_public_detected(self) -> None:
+        result = scan_pii("IP: 8.8.8.8")
+        assert result.decision == ScanDecision.BLOCK
+
+    def test_ipv6_full_detected(self) -> None:
+        result = scan_pii("IPv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "PII-IPV6-001" for m in result.matches)
+
+
+# ---------------------------------------------------------------------------
+# Redaction with Vault
+# ---------------------------------------------------------------------------
+
+
+class TestPiiRedaction:
+    def test_redact_email_with_vault(self) -> None:
+        vault = Vault()
+        scanner = PiiScanner(redact=True, vault=vault)
+        text = "Email me at test@example.com"
+        result = scanner.scan(text)
+        assert "test@example.com" not in result.sanitized
+        assert "[REDACTED_EMAIL_1]" in result.sanitized
+        restored = vault.restore(result.sanitized)
+        assert restored == text
+
+    def test_redact_without_vault_uses_type_placeholder(self) -> None:
+        scanner = PiiScanner(redact=True)
+        result = scanner.scan("Email: test@example.com")
+        assert "[REDACTED_EMAIL]" in result.sanitized
+
+    def test_multiple_pii_get_distinct_placeholders(self) -> None:
+        vault = Vault()
+        scanner = PiiScanner(redact=True, vault=vault)
+        result = scanner.scan("Emails: a@example.com and b@example.com")
+        assert "[REDACTED_EMAIL_1]" in result.sanitized
+        assert "[REDACTED_EMAIL_2]" in result.sanitized
+
+
+# ---------------------------------------------------------------------------
+# Scanner interface contract
+# ---------------------------------------------------------------------------
+
+
+class TestPiiScannerContract:
+    def test_scanner_name(self) -> None:
+        scanner = PiiScanner()
+        assert scanner.name == "pii"
+
+    def test_result_scanner_field(self) -> None:
+        scanner = PiiScanner()
+        result = scanner.scan("hello")
+        assert result.scanner == "pii"
+
+    def test_allow_result_is_valid(self) -> None:
+        result = scan_pii("no pii here")
+        assert result.valid is True
+        assert result.score == 0.0
+        assert result.decision == ScanDecision.ALLOW
+
+    def test_block_result_is_invalid(self) -> None:
+        result = scan_pii("user@example.com")
+        assert result.valid is False
+        assert result.decision == ScanDecision.BLOCK
+
+    def test_matches_have_required_fields(self) -> None:
+        result = scan_pii("user@example.com")
+        assert result.matches
+        m = result.matches[0]
+        assert isinstance(m.pattern, str)
+        assert isinstance(m.start_index, int)
+        assert isinstance(m.end_index, int)
+        assert isinstance(m.category, str)
+
+    def test_reasons_include_type_and_id(self) -> None:
+        result = scan_pii("user@example.com")
+        # Reason format: "<TYPE> (<ID>)"
+        assert any("EMAIL" in r for r in result.reasons)
+
+    def test_block_on_any_false_scores_proportionally(self) -> None:
+        result = scan_pii("user@example.com", block_on_any=False)
+        assert result.score < 1.0
+
+    def test_custom_pattern_merges_with_builtins(self) -> None:
+        import re
+
+        from glin_profanity.scanners.patterns.pii_patterns import PiiPattern
+
+        custom = PiiPattern(
+            id="PII-CUSTOM-001",
+            type="other",
+            pattern=re.compile(r"FAKE_ID_[0-9]{6}"),
+        )
+        scanner = PiiScanner(custom_patterns=[custom])
+        result = scanner.scan("Your ID is FAKE_ID_123456")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "PII-CUSTOM-001" for m in result.matches)

--- a/packages/py/tests/scanners/test_secrets.py
+++ b/packages/py/tests/scanners/test_secrets.py
@@ -1,0 +1,305 @@
+"""
+Tests for SecretsScanner — ported from JS secrets.test.ts on release.
+
+IMPORTANT: All test fixtures use obvious-fake placeholder content that matches
+regex format but will NOT trip GitHub Push Protection.
+"""
+
+import pytest
+
+from glin_profanity.scanners.base import ScanDecision
+from glin_profanity.scanners.secrets import SecretsScanner, scan_secrets
+from glin_profanity.scanners.vault import Vault
+
+
+# ---------------------------------------------------------------------------
+# AWS
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsAws:
+    def test_aws_access_key_id_blocked(self) -> None:
+        # AKIA + 16 uppercase alphanumerics — structurally valid format, fake value
+        key = "AKIA" + "A" * 16
+        result = scan_secrets(f"My key is {key}")
+        assert result.decision == ScanDecision.BLOCK
+        assert result.valid is False
+        assert any(m.pattern == "SEC-AWS-001" for m in result.matches)
+
+    def test_aws_access_key_category_is_family(self) -> None:
+        key = "AKIA" + "B" * 16
+        result = scan_secrets(key)
+        match = next(m for m in result.matches if m.pattern == "SEC-AWS-001")
+        # category carries family, not severity
+        assert match.category == "aws"
+
+    def test_clean_text_allows(self) -> None:
+        result = scan_secrets("Hello, this is a normal message.")
+        assert result.decision == ScanDecision.ALLOW
+        assert result.valid is True
+        assert result.score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# GitHub
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsGitHub:
+    def test_github_pat_classic_blocked(self) -> None:
+        # ghp_ + 36 alphanumeric — fake value
+        token = "ghp_" + "0" * 36
+        result = scan_secrets(token)
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-GH-001" for m in result.matches)
+
+    def test_github_fine_grained_pat_blocked(self) -> None:
+        token = "github_pat_" + "0" * 60
+        result = scan_secrets(token)
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-GH-002" for m in result.matches)
+
+    def test_github_oauth_token_blocked(self) -> None:
+        token = "gho_" + "0" * 36
+        result = scan_secrets(token)
+        assert result.decision == ScanDecision.BLOCK
+
+    def test_github_app_token_blocked(self) -> None:
+        token = "ghu_" + "0" * 36
+        result = scan_secrets(token)
+        assert result.decision == ScanDecision.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsOpenAi:
+    def test_openai_key_blocked(self) -> None:
+        # sk- + 20 alphanum + T3BlbkFJ + 20 alphanum — fake structurally valid
+        key = "sk-" + "A" * 20 + "T3BlbkFJ" + "B" * 20
+        result = scan_secrets(key)
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-OPENAI-001" for m in result.matches)
+
+    def test_openai_project_key_blocked(self) -> None:
+        key = "sk-proj-" + "A" * 50
+        result = scan_secrets(key)
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-OPENAI-002" for m in result.matches)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsAnthropic:
+    def test_anthropic_key_blocked(self) -> None:
+        # sk-ant-api03- + 93 chars — fake structurally valid
+        key = "sk-ant-api03-" + "A" * 93
+        result = scan_secrets(key)
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-ANTHROPIC-001" for m in result.matches)
+
+    def test_anthropic_short_form_blocked(self) -> None:
+        key = "sk-ant-" + "A" * 20
+        result = scan_secrets(key)
+        assert result.decision == ScanDecision.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Stripe
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsStripe:
+    def test_stripe_live_key_blocked(self) -> None:
+        # sk_live_ + 24 alphanum — fake
+        key = "sk_live_" + "0" * 24
+        result = scan_secrets(key)
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-STRIPE-001" for m in result.matches)
+        match = next(m for m in result.matches if m.pattern == "SEC-STRIPE-001")
+        assert match.category == "stripe"
+
+    def test_stripe_test_key_blocked(self) -> None:
+        key = "sk_test_" + "0" * 24
+        result = scan_secrets(key)
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-STRIPE-002" for m in result.matches)
+
+    def test_stripe_publishable_key_blocked(self) -> None:
+        key = "pk_live_" + "0" * 24
+        result = scan_secrets(key)
+        assert result.decision == ScanDecision.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Slack
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsSlack:
+    def test_slack_bot_token_blocked(self) -> None:
+        # xoxb- + 10 digits - 10 digits - 24 alphanumeric
+        token = "xoxb-" + "0" * 10 + "-" + "0" * 10 + "-" + "A" * 24
+        result = scan_secrets(token)
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-SLACK-001" for m in result.matches)
+
+    def test_slack_webhook_blocked(self) -> None:
+        webhook = "https://hooks.slack.com/services/T" + "A" * 9 + "/B" + "A" * 9 + "/" + "A" * 24
+        result = scan_secrets(webhook)
+        assert result.decision == ScanDecision.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Private Key / JWT
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsCrypto:
+    def test_rsa_private_key_blocked(self) -> None:
+        result = scan_secrets("-----BEGIN RSA PRIVATE KEY-----\nFAKEDATA\n-----END RSA PRIVATE KEY-----")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-KEY-001" for m in result.matches)
+
+    def test_openssh_private_key_blocked(self) -> None:
+        result = scan_secrets("-----BEGIN OPENSSH PRIVATE KEY-----\nFAKEDATA")
+        assert result.decision == ScanDecision.BLOCK
+
+    def test_jwt_with_high_entropy_blocked(self) -> None:
+        # Structurally valid JWT-like token with high entropy
+        header = "eyJhbGciOiJIUzI1NiJ9"
+        payload = "eyJzdWIiOiJ0ZXN0dXNlciJ9"
+        sig = "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        jwt = f"{header}.{payload}.{sig}"
+        result = scan_secrets(jwt)
+        assert result.decision == ScanDecision.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Entropy gating
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsEntropyGating:
+    def test_low_entropy_base64_not_blocked(self) -> None:
+        # A repeated Base64 string near keyword — low entropy, should not block
+        text = "key = " + "A" * 32
+        result = scan_secrets(text)
+        # Low entropy patterns with entropyCheck should not fire on repeated chars
+        # The generic SEC-GEN-004 pattern has entropyCheck, so 'AAAA...' should not fire
+        assert result.decision == ScanDecision.ALLOW
+
+    def test_high_entropy_base64_near_keyword_blocked(self) -> None:
+        # A high-entropy Base64 string near a secret keyword
+        text = 'secret = "dGhpcyBpcyBhIHJlYWxseSBsb25nIHNlY3JldCBrZXkgd2l0aCBoaWdoIGVudHJvcHk="'
+        result = scan_secrets(text)
+        assert result.decision == ScanDecision.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# Vault redact + restore roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsVaultRoundtrip:
+    def test_redact_and_restore_roundtrip(self) -> None:
+        vault = Vault()
+        key = "AKIA" + "C" * 16
+        original_text = f"My AWS key is {key} please keep it safe."
+
+        scanner = SecretsScanner(redact=True, vault=vault)
+        result = scanner.scan(original_text)
+
+        assert result.decision == ScanDecision.BLOCK
+        assert key not in result.sanitized
+        assert "[REDACTED_" in result.sanitized
+
+        restored = vault.restore(result.sanitized)
+        assert restored == original_text
+
+    def test_redact_without_vault_uses_generic_placeholder(self) -> None:
+        key = "AKIA" + "D" * 16
+        scanner = SecretsScanner(redact=True)
+        result = scanner.scan(f"key={key}")
+        assert "[REDACTED]" in result.sanitized
+
+    def test_multiple_secrets_get_distinct_placeholders(self) -> None:
+        vault = Vault()
+        key1 = "AKIA" + "E" * 16
+        key2 = "AKIA" + "F" * 16
+        scanner = SecretsScanner(redact=True, vault=vault)
+        result = scanner.scan(f"{key1} and {key2}")
+        assert "[REDACTED_AWS_1]" in result.sanitized
+        assert "[REDACTED_AWS_2]" in result.sanitized
+
+    def test_vault_restore_case_insensitive(self) -> None:
+        vault = Vault()
+        key = "AKIA" + "G" * 16
+        scanner = SecretsScanner(redact=True, vault=vault)
+        result = scanner.scan(key)
+        placeholder = result.sanitized
+        # Force case change
+        upper = placeholder.upper()
+        restored = vault.restore(upper, strategy="case_insensitive")
+        assert restored == key
+
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsOptions:
+    def test_block_on_any_false_uses_proportional_score(self) -> None:
+        key = "AKIA" + "H" * 16
+        result = scan_secrets(key, block_on_any=False)
+        assert result.score < 1.0
+
+    def test_scanner_name_is_secrets(self) -> None:
+        scanner = SecretsScanner()
+        assert scanner.name == "secrets"
+
+    def test_result_scanner_field_matches_name(self) -> None:
+        scanner = SecretsScanner()
+        result = scanner.scan("hello world")
+        assert result.scanner == "secrets"
+
+    def test_allow_result_shape(self) -> None:
+        result = scan_secrets("nothing sensitive here")
+        assert result.valid is True
+        assert result.score == 0.0
+        assert result.matches == []
+
+    def test_matches_contain_required_fields(self) -> None:
+        key = "AKIA" + "I" * 16
+        result = scan_secrets(key)
+        assert result.matches
+        m = result.matches[0]
+        assert isinstance(m.pattern, str)
+        assert isinstance(m.start_index, int)
+        assert isinstance(m.end_index, int)
+        assert isinstance(m.category, str)
+
+    def test_custom_pattern_merges_with_builtins(self) -> None:
+        import re
+
+        from glin_profanity.scanners.patterns.secret_patterns import SecretPattern
+
+        custom = SecretPattern(
+            id="SEC-CUSTOM-001",
+            name="Custom Test Pattern",
+            pattern=re.compile(r"FAKESECRET_[A-Z]{10}"),
+            severity="high",
+            family="custom_test",
+        )
+        scanner = SecretsScanner(custom_patterns=[custom])
+        result = scanner.scan("token: FAKESECRET_ABCDEFGHIJ")
+        assert result.decision == ScanDecision.BLOCK
+        assert any(m.pattern == "SEC-CUSTOM-001" for m in result.matches)
+        match = next(m for m in result.matches if m.pattern == "SEC-CUSTOM-001")
+        assert match.category == "custom_test"

--- a/packages/py/tests/scanners/test_vault.py
+++ b/packages/py/tests/scanners/test_vault.py
@@ -1,0 +1,241 @@
+"""
+Tests for Vault — ported from JS vault.test.ts on release.
+"""
+
+import pytest
+
+from glin_profanity.scanners.vault import Vault
+
+
+# ---------------------------------------------------------------------------
+# Basic store / restore
+# ---------------------------------------------------------------------------
+
+
+class TestVaultBasic:
+    def test_store_returns_placeholder(self) -> None:
+        vault = Vault()
+        placeholder = vault.store("email", "user@example.com")
+        assert placeholder == "[REDACTED_EMAIL_1]"
+
+    def test_store_increments_counter(self) -> None:
+        vault = Vault()
+        p1 = vault.store("email", "a@example.com")
+        p2 = vault.store("email", "b@example.com")
+        assert p1 == "[REDACTED_EMAIL_1]"
+        assert p2 == "[REDACTED_EMAIL_2]"
+
+    def test_distinct_types_have_independent_counters(self) -> None:
+        vault = Vault()
+        e1 = vault.store("email", "a@example.com")
+        p1 = vault.store("phone", "+12025551234")
+        e2 = vault.store("email", "b@example.com")
+        assert e1 == "[REDACTED_EMAIL_1]"
+        assert p1 == "[REDACTED_PHONE_1]"
+        assert e2 == "[REDACTED_EMAIL_2]"
+
+    def test_type_is_normalized_to_upper(self) -> None:
+        vault = Vault()
+        placeholder = vault.store("Credit Card", "4111 1111 1111 1111")
+        assert placeholder == "[REDACTED_CREDIT_CARD_1]"
+
+    def test_size_reflects_stored_entries(self) -> None:
+        vault = Vault()
+        assert vault.size() == 0
+        vault.store("email", "x@example.com")
+        assert vault.size() == 1
+        vault.store("phone", "+12025551234")
+        assert vault.size() == 2
+
+    def test_clear_resets_entries_and_counters(self) -> None:
+        vault = Vault()
+        vault.store("email", "x@example.com")
+        vault.clear()
+        assert vault.size() == 0
+        placeholder = vault.store("email", "y@example.com")
+        # Counter reset — should be _1 again
+        assert placeholder == "[REDACTED_EMAIL_1]"
+
+    def test_get_entries_returns_snapshot(self) -> None:
+        vault = Vault()
+        vault.store("email", "test@example.com")
+        entries = vault.get_entries()
+        assert len(entries) == 1
+        assert entries[0]["placeholder"] == "[REDACTED_EMAIL_1]"
+        assert entries[0]["original"] == "test@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Restore strategy: exact
+# ---------------------------------------------------------------------------
+
+
+class TestVaultRestoreExact:
+    def test_exact_restore_replaces_placeholder(self) -> None:
+        vault = Vault()
+        original = "user@example.com"
+        placeholder = vault.store("email", original)
+        text = f"Contact: {placeholder} for info."
+        restored = vault.restore(text, strategy="exact")
+        assert restored == f"Contact: {original} for info."
+
+    def test_exact_restore_multiple_entries(self) -> None:
+        vault = Vault()
+        p1 = vault.store("email", "alice@example.com")
+        p2 = vault.store("email", "bob@example.com")
+        text = f"{p1} and {p2}"
+        restored = vault.restore(text)
+        assert restored == "alice@example.com and bob@example.com"
+
+    def test_exact_restore_unchanged_if_no_placeholder(self) -> None:
+        vault = Vault()
+        vault.store("email", "test@example.com")
+        text = "No placeholders here."
+        assert vault.restore(text) == text
+
+    def test_exact_restore_case_sensitive(self) -> None:
+        vault = Vault()
+        # Use lowercase type so the placeholder has mixed case when uppercased
+        p = vault.store("apikey", "test_secret_value")
+        # p = "[REDACTED_APIKEY_1]" — already uppercase, so mutate one bracket
+        mutated = p.replace("[", "(").replace("]", ")")
+        # Mutated form should NOT be restored by exact match
+        assert vault.restore(mutated, strategy="exact") == mutated
+
+
+# ---------------------------------------------------------------------------
+# Restore strategy: case_insensitive
+# ---------------------------------------------------------------------------
+
+
+class TestVaultRestoreCaseInsensitive:
+    def test_case_insensitive_restores_upper_placeholder(self) -> None:
+        vault = Vault()
+        original = "user@example.com"
+        placeholder = vault.store("email", original)
+        text = placeholder.upper()
+        restored = vault.restore(text, strategy="case_insensitive")
+        assert restored == original
+
+    def test_case_insensitive_restores_mixed_case(self) -> None:
+        vault = Vault()
+        original = "secret_value"
+        placeholder = vault.store("token", original)
+        mixed = placeholder.lower()
+        restored = vault.restore(mixed, strategy="case_insensitive")
+        assert restored == original
+
+    def test_case_insensitive_handles_no_match(self) -> None:
+        vault = Vault()
+        vault.store("email", "test@example.com")
+        text = "nothing to match"
+        assert vault.restore(text, strategy="case_insensitive") == text
+
+
+# ---------------------------------------------------------------------------
+# Restore strategy: fuzzy
+# ---------------------------------------------------------------------------
+
+
+class TestVaultRestoreFuzzy:
+    def test_fuzzy_restores_exact_match(self) -> None:
+        vault = Vault()
+        original = "secret123"
+        placeholder = vault.store("token", original)
+        restored = vault.restore(placeholder, strategy="fuzzy")
+        assert restored == original
+
+    def test_fuzzy_tolerates_single_typo(self) -> None:
+        vault = Vault()
+        original = "user@example.com"
+        placeholder = vault.store("email", original)
+        # Introduce a one-character typo in the placeholder
+        typo = placeholder[:5] + "X" + placeholder[6:]
+        # fuzzy with tolerance 3 should still restore
+        restored = vault.restore(typo, strategy="fuzzy")
+        assert restored == original
+
+    def test_fuzzy_tolerates_two_typos(self) -> None:
+        vault = Vault()
+        original = "test_value"
+        placeholder = vault.store("secret", original)
+        # Introduce two character changes
+        typo = placeholder[:4] + "XY" + placeholder[6:]
+        restored = vault.restore(typo, strategy="fuzzy")
+        assert restored == original
+
+    def test_fuzzy_does_not_restore_wildly_different_string(self) -> None:
+        vault = Vault()
+        vault.store("email", "test@example.com")
+        text = "completely_different_string_that_should_not_match"
+        # Should not corrupt the text
+        restored = vault.restore(text, strategy="fuzzy")
+        assert restored == text
+
+
+# ---------------------------------------------------------------------------
+# Restore strategy: combined
+# ---------------------------------------------------------------------------
+
+
+class TestVaultRestoreCombined:
+    def test_combined_prefers_exact(self) -> None:
+        vault = Vault()
+        original = "secret_value"
+        placeholder = vault.store("token", original)
+        restored = vault.restore(placeholder, strategy="combined")
+        assert restored == original
+
+    def test_combined_falls_back_to_case_insensitive(self) -> None:
+        vault = Vault()
+        original = "secret_value"
+        placeholder = vault.store("token", original)
+        upper = placeholder.upper()
+        restored = vault.restore(upper, strategy="combined")
+        assert restored == original
+
+    def test_combined_falls_back_to_fuzzy(self) -> None:
+        vault = Vault()
+        original = "user@example.com"
+        placeholder = vault.store("email", original)
+        # Use a typo that's not simply a case change
+        typo = placeholder[:4] + "X" + placeholder[5:]
+        restored = vault.restore(typo, strategy="combined")
+        assert restored == original
+
+    def test_combined_unchanged_if_no_match(self) -> None:
+        vault = Vault()
+        vault.store("email", "test@example.com")
+        text = "nothing_remotely_similar"
+        assert vault.restore(text, strategy="combined") == text
+
+
+# ---------------------------------------------------------------------------
+# Integration with SecretsScanner
+# ---------------------------------------------------------------------------
+
+
+class TestVaultIntegrationWithSecrets:
+    def test_secrets_redact_and_vault_restore(self) -> None:
+        from glin_profanity.scanners.secrets import SecretsScanner
+
+        vault = Vault()
+        key = "AKIA" + "Z" * 16
+        text = f"AWS key: {key}"
+        scanner = SecretsScanner(redact=True, vault=vault)
+        result = scanner.scan(text)
+        assert key not in result.sanitized
+        assert vault.size() == 1
+        restored = vault.restore(result.sanitized)
+        assert restored == text
+
+    def test_pii_redact_and_vault_restore(self) -> None:
+        from glin_profanity.scanners.pii import PiiScanner
+
+        vault = Vault()
+        scanner = PiiScanner(redact=True, vault=vault)
+        text = "Email: admin@example.com, IP: 10.0.0.1"
+        result = scanner.scan(text)
+        assert "admin@example.com" not in result.sanitized
+        restored = vault.restore(result.sanitized)
+        assert "admin@example.com" in restored


### PR DESCRIPTION
## Summary

- Python parity for PR #120 scanners: 110 secret patterns, 27 PII patterns, Vault with 4 restore strategies
- Matches JS behavior exactly: family-based `ScanMatch.category`, dedup overlapping ranges, Luhn + IBAN mod-97 validators
- 135 tests total (44 existing prompt-injection + 91 new), ruff clean, zero new mypy errors in scanner modules

## Test plan

- [ ] `cd packages/py && python3.12 -m pytest tests/scanners/ -v` — all 135 pass
- [ ] `ruff check glin_profanity/scanners/` — zero issues
- [ ] `mypy glin_profanity/scanners/` — zero new errors (2 pre-existing in filter.py)
- [ ] Import smoke: `python3 -c "from glin_profanity import SecretsScanner, PiiScanner, Vault; s = SecretsScanner(); print(s.scan('AKIA' + 'A'*16).decision)"` prints `ScanDecision.BLOCK`
- [ ] Vault roundtrip: redact AWS key, restore with `vault.restore()` → original text recovered
- [ ] Luhn invalid card `4111 1111 1111 1112` does NOT fire
- [ ] IBAN `DE89370400440532013000` detected; `DE00...` (wrong checksum) rejected