### PR TITLE
feat(vscode): scaffold VS Code extension

### DIFF
--- a/packages/vscode-extension/.gitignore
+++ b/packages/vscode-extension/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.vsix

--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -1,0 +1,8 @@
+src/
+tsconfig.json
+node_modules/
+.vscode/
+.gitignore
+.eslintrc*
+*.test.ts
+**/*.map

--- a/packages/vscode-extension/CHANGELOG.md
+++ b/packages/vscode-extension/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.1.0] — 2026-04-20
+- Initial scaffold
+- Support for profanity, prompt-injection, secrets, PII scanning
+- Config for on-save vs on-type

--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -1,0 +1,49 @@
+# Glin Profanity — AI Guardrail for VS Code
+
+Highlight **profanity**, **PII**, **secrets**, and **prompt-injection** directly in your editor,
+powered by the [glin-profanity](https://github.com/glincker/glin-profanity) scanner suite.
+
+## Features
+
+- Red squiggles for secrets (API keys, tokens) and prompt-injection attempts
+- Yellow squiggles for profanity and personally identifiable information (PII)
+- Scan on save (default) or on every keystroke (opt-in, debounced 500 ms)
+- Configurable scanner subset — run only the checks you need
+- Three strictness levels: `lenient`, `moderate`, `strict`
+- Works offline — no network calls, no telemetry
+
+## Configuration
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `glinProfanity.enableOnSave` | boolean | `true` | Scan whenever a file is saved |
+| `glinProfanity.enableOnType` | boolean | `false` | Scan as you type (debounced 500 ms) |
+| `glinProfanity.scanners` | string[] | `["profanity","secrets","pii"]` | Active scanners |
+| `glinProfanity.strictness` | string | `"moderate"` | Detection aggressiveness |
+
+### Available scanners
+- `profanity` — multi-language profanity (24 languages, leetspeak-aware)
+- `injection` — prompt-injection and jailbreak patterns
+- `secrets` — API keys, tokens, credentials, private keys
+- `pii` — emails, phone numbers, SSNs, credit cards, IBANs
+
+## Commands
+
+- **Glin Profanity: Scan Active File** — trigger a manual scan
+- **Glin Profanity: Clear Diagnostics** — remove all highlights
+
+## Installation
+
+Once published to the VS Code Marketplace (follow-up sprint):
+
+```
+ext install glincker.glin-profanity-vscode
+```
+
+## Screenshots
+
+<!-- TODO: add screenshots after first Marketplace publish -->
+
+## License
+
+MIT — same as the core glin-profanity library.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "glin-profanity-vscode",
+  "displayName": "Glin Profanity — AI Guardrail",
+  "description": "Highlight profanity, PII, secrets, and prompt-injection in your editor.",
+  "version": "0.1.0",
+  "publisher": "glincker",
+  "engines": { "vscode": "^1.90.0" },
+  "categories": ["Linters", "Other"],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "Glin Profanity",
+      "properties": {
+        "glinProfanity.enableOnSave": { "type": "boolean", "default": true },
+        "glinProfanity.enableOnType": { "type": "boolean", "default": false },
+        "glinProfanity.scanners": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["profanity", "injection", "secrets", "pii"] },
+          "default": ["profanity", "secrets", "pii"]
+        },
+        "glinProfanity.strictness": {
+          "type": "string",
+          "enum": ["lenient", "moderate", "strict"],
+          "default": "moderate"
+        }
+      }
+    },
+    "commands": [
+      { "command": "glinProfanity.scanActiveFile", "title": "Glin Profanity: Scan Active File" },
+      { "command": "glinProfanity.clearDiagnostics", "title": "Glin Profanity: Clear Diagnostics" }
+    ]
+  },
+  "scripts": {
+    "build": "tsup src/extension.ts --format cjs --external vscode",
+    "watch": "tsup src/extension.ts --format cjs --external vscode --watch",
+    "package": "vsce package"
+  },
+  "dependencies": {
+    "glin-profanity": "file:../js"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "@types/vscode": "^1.90.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "@vscode/vsce": "^3.0.0"
+  }
+}

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,0 +1,207 @@
+/**
+ * Glin Profanity VS Code Extension
+ *
+ * Highlights profanity, PII, secrets, and prompt-injection in the active editor
+ * using the glin-profanity scanner suite.
+ */
+
+import * as vscode from 'vscode';
+import { checkProfanity } from 'glin-profanity';
+import {
+  PromptInjectionScanner,
+  SecretsScanner,
+  PiiScanner,
+  type ScanMatch,
+  type ScanContext,
+} from 'glin-profanity/scanners';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type ScannerKey = 'profanity' | 'injection' | 'secrets' | 'pii';
+type Strictness = 'lenient' | 'moderate' | 'strict';
+
+interface ExtensionConfig {
+  enableOnSave: boolean;
+  enableOnType: boolean;
+  scanners: ScannerKey[];
+  strictness: Strictness;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const MAX_FILE_SIZE_BYTES = 1_000_000; // 1 MB
+const ON_TYPE_DEBOUNCE_MS = 500;
+const DIAGNOSTIC_SOURCE = 'glin-profanity';
+
+// ─── Globals ─────────────────────────────────────────────────────────────────
+
+let diagnosticCollection: vscode.DiagnosticCollection;
+let onTypeTimer: ReturnType<typeof setTimeout> | undefined;
+
+// ─── Config helper ───────────────────────────────────────────────────────────
+
+function getConfig(): ExtensionConfig {
+  const cfg = vscode.workspace.getConfiguration('glinProfanity');
+  return {
+    enableOnSave: cfg.get<boolean>('enableOnSave', true),
+    enableOnType: cfg.get<boolean>('enableOnType', false),
+    scanners: cfg.get<ScannerKey[]>('scanners', ['profanity', 'secrets', 'pii']),
+    strictness: cfg.get<Strictness>('strictness', 'moderate'),
+  };
+}
+
+// ─── Diagnostic builders ─────────────────────────────────────────────────────
+
+function buildRange(doc: vscode.TextDocument, startIndex: number, endIndex: number): vscode.Range {
+  return new vscode.Range(doc.positionAt(startIndex), doc.positionAt(endIndex));
+}
+
+function matchesToDiagnostics(
+  doc: vscode.TextDocument,
+  matches: ScanMatch[],
+  severity: vscode.DiagnosticSeverity,
+  source: string,
+): vscode.Diagnostic[] {
+  return matches.map((m) => {
+    const range = buildRange(doc, m.startIndex, m.endIndex);
+    const diag = new vscode.Diagnostic(
+      range,
+      `[${source}] ${m.pattern} (${m.category})`,
+      severity,
+    );
+    diag.source = DIAGNOSTIC_SOURCE;
+    diag.code = m.category;
+    return diag;
+  });
+}
+
+// ─── Core scan ───────────────────────────────────────────────────────────────
+
+async function scanDocument(doc: vscode.TextDocument): Promise<void> {
+  // Skip large / binary files
+  if (doc.getText().length > MAX_FILE_SIZE_BYTES) {
+    return;
+  }
+
+  const config = getConfig();
+  const text = doc.getText();
+  const diagnostics: vscode.Diagnostic[] = [];
+  const ctx: ScanContext = { strictness: config.strictness };
+
+  // ── Profanity scanner ──────────────────────────────────────────────────────
+  if (config.scanners.includes('profanity')) {
+    const result = checkProfanity(text);
+    if (result.containsProfanity && result.matches) {
+      for (const match of result.matches) {
+        if (match.isWhitelisted) continue;
+        // checkProfanity uses match.index; derive end from word length
+        const start = match.index;
+        const end = start + match.word.length;
+        const range = buildRange(doc, start, end);
+        const diag = new vscode.Diagnostic(
+          range,
+          `[profanity] "${match.word}"`,
+          vscode.DiagnosticSeverity.Warning,
+        );
+        diag.source = DIAGNOSTIC_SOURCE;
+        diag.code = 'profanity';
+        diagnostics.push(diag);
+      }
+    }
+  }
+
+  // ── Prompt-injection scanner ───────────────────────────────────────────────
+  if (config.scanners.includes('injection')) {
+    const scanner = new PromptInjectionScanner({ strictness: config.strictness });
+    const result = await Promise.resolve(scanner.scan(text, ctx));
+    if (!result.valid && result.matches && result.matches.length > 0) {
+      diagnostics.push(
+        ...matchesToDiagnostics(doc, result.matches, vscode.DiagnosticSeverity.Error, 'injection'),
+      );
+    }
+  }
+
+  // ── Secrets scanner ────────────────────────────────────────────────────────
+  if (config.scanners.includes('secrets')) {
+    const scanner = new SecretsScanner();
+    const result = await Promise.resolve(scanner.scan(text, ctx));
+    if (!result.valid && result.matches && result.matches.length > 0) {
+      diagnostics.push(
+        ...matchesToDiagnostics(doc, result.matches, vscode.DiagnosticSeverity.Error, 'secret'),
+      );
+    }
+  }
+
+  // ── PII scanner ────────────────────────────────────────────────────────────
+  if (config.scanners.includes('pii')) {
+    const scanner = new PiiScanner();
+    const result = await Promise.resolve(scanner.scan(text, ctx));
+    if (!result.valid && result.matches && result.matches.length > 0) {
+      diagnostics.push(
+        ...matchesToDiagnostics(doc, result.matches, vscode.DiagnosticSeverity.Warning, 'pii'),
+      );
+    }
+  }
+
+  diagnosticCollection.set(doc.uri, diagnostics);
+}
+
+// ─── Activation ──────────────────────────────────────────────────────────────
+
+export function activate(context: vscode.ExtensionContext): void {
+  diagnosticCollection = vscode.languages.createDiagnosticCollection(DIAGNOSTIC_SOURCE);
+  context.subscriptions.push(diagnosticCollection);
+
+  // Command: scan active file manually
+  context.subscriptions.push(
+    vscode.commands.registerCommand('glinProfanity.scanActiveFile', () => {
+      const doc = vscode.window.activeTextEditor?.document;
+      if (doc) {
+        void scanDocument(doc);
+      }
+    }),
+  );
+
+  // Command: clear all diagnostics
+  context.subscriptions.push(
+    vscode.commands.registerCommand('glinProfanity.clearDiagnostics', () => {
+      diagnosticCollection.clear();
+    }),
+  );
+
+  // Event: on save
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument((doc) => {
+      if (getConfig().enableOnSave) {
+        void scanDocument(doc);
+      }
+    }),
+  );
+
+  // Event: on type (debounced)
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      if (!getConfig().enableOnType) return;
+      if (onTypeTimer !== undefined) {
+        clearTimeout(onTypeTimer);
+      }
+      onTypeTimer = setTimeout(() => {
+        void scanDocument(event.document);
+        onTypeTimer = undefined;
+      }, ON_TYPE_DEBOUNCE_MS);
+    }),
+  );
+
+  // Scan already-open editors on activation
+  if (vscode.window.activeTextEditor) {
+    void scanDocument(vscode.window.activeTextEditor.document);
+  }
+}
+
+export function deactivate(): void {
+  if (onTypeTimer !== undefined) {
+    clearTimeout(onTypeTimer);
+    onTypeTimer = undefined;
+  }
+  diagnosticCollection?.dispose();
+}

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- New `packages/vscode-extension/` package — VS Code extension v0.1.0
- Registers a `glin-profanity` diagnostic collection, scanning on save (and optionally on type, debounced 500 ms)
- Uses `glin-profanity/scanners` sub-path for `PromptInjectionScanner`, `SecretsScanner`, `PiiScanner`; top-level `checkProfanity` for the profanity scanner
- Configurable scanner subset (`profanity`, `injection`, `secrets`, `pii`) and strictness level (`lenient` / `moderate` / `strict`)

## Test plan

- [ ] `npm install` succeeds inside `packages/vscode-extension/`
- [ ] `npm run build` produces `dist/extension.js` (~6 KB)
- [ ] `npx tsc --noEmit` reports zero errors
- [ ] Open a `.ts` file with a hardcoded API key in VS Code (with extension loaded via `F5`) — red squiggle appears under the secret
- [ ] Clear diagnostics command removes all highlights
- [ ] On-type scanning can be enabled via settings and fires debounced

## Notes

- `glin-profanity` dependency points to `file:../js` (workspace local) because the `./scanners` sub-path export is not yet published to npm (v3.3.0 on registry omits it). Once the scanners are in a published release, change to `^3.2.1` or later.
- No root workspace files modified.
- Publishing flow documented in README for follow-up sprint.