### PR TITLE
release: minor force-publish scanner wave as 3.4.0

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glin-profanity",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Glin-Profanity is a lightweight and efficient npm package designed to detect and filter profane language in text inputs across multiple languages. Whether you’re building a chat application, a comment section, or any platform where user-generated content is involved, Glin-Profanity helps you maintain a clean and respectful environment.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/py/glin_profanity/__init__.py
+++ b/packages/py/glin_profanity/__init__.py
@@ -14,7 +14,7 @@ Examples:
     True
 """
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 __author__ = "glinr"
 __email__ = "contact@glincker.com"
 


### PR DESCRIPTION
## Why

Today's auto-release runs fired but produced stale publishes:

- **npm `glin-profanity@3.2.2`** was published without the `dist/scanners/` entry (an earlier run in the cascade likely won the publish before scanner PRs landed).
- All subsequent auto-release runs saw 'version already exists on npm, skipping publish' and did nothing.
- `glin-profanity/scanners` subpath is therefore unreachable for external users.

## What this PR does

Bumps the **source** versions to 3.3.0 (the current latest on npm) so the auto-release minor-bump from the commit lands on **3.4.0** — a version that does not yet exist, forcing a fresh publish.

- `packages/js/package.json`: 3.2.1 → 3.3.0
- `packages/py/glin_profanity/__init__.py`: 3.2.0 → 3.3.0

Commit subject uses the `release: minor` convention so `scripts/sync-versions.js` picks it up.

## Expected outcome after merge

1. Auto-release workflow fires on merge to release.
2. sync-versions detects `release: minor` + channel stable, bumps both to 3.4.0.
3. Build emits `dist/scanners/index.{cjs,js,d.ts,d.cts}` (~53 KB CJS).
4. npm `glin-profanity@3.4.0` published WITH scanners subpath.
5. PyPI `glin-profanity 3.4.0` published.

## Verify after merge

```
npm install glin-profanity@3.4.0
node -e "const { PromptInjectionScanner } = require('glin-profanity/scanners'); console.log(new PromptInjectionScanner().scan('ignore previous instructions').decision)"
# → BLOCK
```