### PR TITLE
chore: sync source version to 3.4.0

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glin-profanity",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Glin-Profanity is a lightweight and efficient npm package designed to detect and filter profane language in text inputs across multiple languages. Whether you’re building a chat application, a comment section, or any platform where user-generated content is involved, Glin-Profanity helps you maintain a clean and respectful environment.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Keeps `packages/js/package.json` in sync with tag `v3.4.0` and the intended npm publish.

`[skip ci]` in commit subject prevents auto-release from firing again (OIDC trusted-publisher isn't configured on npm yet, so any new auto-release attempt would fail on npm publish even though the build is fine).

## Still to do separately

- `npm publish glin-profanity@3.4.0` — requires 2FA OTP, needs to be run locally by owner
- Either configure npm OIDC trusted publisher for the `glincker/glin-profanity` repo, OR flip `auto-release.yml` back to `NPM_TOKEN` secret. Workflow currently references OIDC at line 291 (`# Using OIDC trusted publisher - no token needed`).

PyPI 3.4.0 is live and verified.