### PR TITLE
chore: sync py source version to 3.4.0

### DIFF
--- a/packages/py/glin_profanity/__init__.py
+++ b/packages/py/glin_profanity/__init__.py
@@ -14,7 +14,7 @@ Examples:
     True
 """
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 __author__ = "glinr"
 __email__ = "contact@glincker.com"
 


### PR DESCRIPTION
Mirrors #137 on the Python side. PyPI already has 3.4.0 live; source was still at 3.3.0.